### PR TITLE
feat: cassandra vector db client

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ The VectorDB component stores the embedding vectors, as well as a small amount o
 
 The currently available options are:
 - `BasicVectorDB`
+- `CassandraVectorDB`
 
 #### ChunkDB
 The ChunkDB stores the content of text chunks in a nested dictionary format, keyed on `doc_id` and `chunk_index`. This is used by RSE to retrieve the full text associated with specific chunks.

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,0 +1,30 @@
+version: "3"
+services:
+  cassandra:
+    image: cassandra:5
+    environment:
+      - CASSANDRA_LISTEN_ADDRESS=cassandra
+    ports:
+      - 9042:9042
+    healthcheck:
+      test: ["CMD", "cqlsh"]
+      start_interval: 10s
+      interval: 5s
+      timeout: 15s
+      retries: 6
+
+  tests:
+    build:
+      context: ../
+      dockerfile: docker/test.Dockerfile
+    volumes:
+      - ../:/app
+    image: myapp-tests
+    environment:
+      - CO_API_KEY=$CO_API_KEY
+      - OPENAI_API_KEY=$OPENAI_API_KEY
+      - ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY
+      - VOYAGE_API_KEY=$VOYAGE_API_KEY
+    depends_on:
+      cassandra:
+        condition: service_healthy

--- a/docker/test.Dockerfile
+++ b/docker/test.Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.9
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+
+CMD ["python", "-m", "unittest", "discover", "-s", "tests/unit"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,5 @@ langchain-text-splitters
 PyPDF2
 docx2txt
 pandas
+cassandra-driver
+cassio

--- a/run_tests.ps1
+++ b/run_tests.ps1
@@ -1,0 +1,2 @@
+cd docker
+docker compose up --build --abort-on-container-exit

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd docker
+docker compose up --build --abort-on-container-exit

--- a/sprag/vector_db_connectors/cassandra_vector_db.py
+++ b/sprag/vector_db_connectors/cassandra_vector_db.py
@@ -1,0 +1,97 @@
+import cassio
+from cassio.table import MetadataVectorCassandraTable
+from sprag.vector_db import VectorDB
+
+
+class CassandraVectorDB(VectorDB):
+
+    def __init__(
+        self,
+        contact_points,
+        keyspace,
+        table,
+        username=None,
+        password=None,
+    ):
+        """
+        Initializes a CassandraVectorDB instance.
+
+        Args:
+            contact_points (list): List of contact points for the Cassandra cluster.
+            keyspace (str): Name of the keyspace to use.
+            table (str): Name of the table to use.
+            username (str, optional): Username for authentication. Defaults to None.
+            password (str, optional): Password for authentication. Defaults to None.
+        """
+        self.table = table
+        self.v_table = None
+
+        cassio.init(
+            contact_points=contact_points,
+            keyspace=keyspace,
+            username=username,
+            password=password,
+        )
+        cassio.config.resolve_session().execute(
+            f"CREATE KEYSPACE IF NOT EXISTS {keyspace} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor': 1}}"
+        )
+
+    def add_vectors(self, vectors, metadata):
+        """
+        Adds vectors and their associated metadata to Cassandra.
+
+        Args:
+            vectors (list): A list of vectors (numpy arrays) to add.
+            metadata (list): A list of dictionaries containing metadata for each vector.
+        """
+        if self.v_table is None and vectors is not None and len(vectors) > 0:
+            self.v_table = MetadataVectorCassandraTable(
+                table=self.table,
+                vector_dimension=len(vectors[0]),
+                primary_key_type="TEXT",
+            )
+
+        for vector, meta in zip(vectors, metadata):
+            vector_list = vector.tolist()
+            self.v_table.put_async(
+                row_id=meta["doc_id"],  # Assuming doc_id is used as the primary key
+                vector=vector_list,
+                metadata=meta,
+            ).result()
+
+    def search(self, query_vector, top_k=10):
+        """
+        Searches for the top-k most similar vectors to the query vector using cosine similarity.
+
+        Args:
+            query_vector (np.array): The query vector.
+            top_k (int, optional): The number of results to return. Defaults to 10.
+
+        Returns:
+            list: A list of dictionaries containing the metadata and similarity scores of the results.
+        """
+        if self.v_table is None:
+            return []
+
+        results = self.v_table.metric_ann_search(
+            vector=query_vector.tolist(), n=top_k, metric="cos"
+        )
+
+        return [
+            {
+                "metadata": match["metadata"],
+                "similarity": match[
+                    "distance"
+                ],  # Distance is "similarity" in this version of Cassio
+            }
+            for match in results
+        ]
+
+    def remove_document(self, doc_id):
+        """
+        Removes a document (vector and metadata) from Cassandra based on the document ID.
+
+        Args:
+            doc_id (str): The ID of the document to remove.
+        """
+        self.v_table.delete(row_id=doc_id)

--- a/sprag/vector_db_connectors/cassandra_vector_db.py
+++ b/sprag/vector_db_connectors/cassandra_vector_db.py
@@ -83,6 +83,8 @@ class CassandraVectorDB(VectorDB):
                 "similarity": match[
                     "distance"
                 ],  # Distance is "similarity" in this version of Cassio
+                "vector": match["vector"],
+                "doc_id": match["row_id"],
             }
             for match in results
         ]

--- a/tests/unit/test_cassandra_vector_db.py
+++ b/tests/unit/test_cassandra_vector_db.py
@@ -54,6 +54,7 @@ class TestCassandraVectorDB(unittest.TestCase):
 
         self.assertEqual(len(results), 2)
         self.assertEqual(results[0]["metadata"]["doc_id"], "doc1")
+        self.assertEqual(results[0]["doc_id"], "doc1")
         self.assertAlmostEqual(results[0]["similarity"], 1.0)
 
     def test_remove_document(self):

--- a/tests/unit/test_cassandra_vector_db.py
+++ b/tests/unit/test_cassandra_vector_db.py
@@ -1,0 +1,77 @@
+import sys
+import os
+import unittest
+import cassio
+import numpy as np
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+from sprag.vector_db_connectors.cassandra_vector_db import CassandraVectorDB
+
+CONTACT_POINTS = ["cassandra", "127.0.0.1"]
+KEYSPACE = "my_keyspace"
+TABLE = "my_vector_table"
+USERNAME = None
+PASSWORD = None
+
+
+class TestCassandraVectorDB(unittest.TestCase):
+    def setUp(self):
+        self.db = CassandraVectorDB(CONTACT_POINTS, KEYSPACE, TABLE, USERNAME, PASSWORD)
+        # Clear the table before each test
+        my_table = cassio.table.MetadataVectorCassandraTable(
+            table=TABLE,
+            vector_dimension=len(np.array([1, 2, 3])),
+            primary_key_type="TEXT",
+        )
+        my_table.clear()
+
+    def test_add_and_search_vectors(self):
+        vectors = [np.array([1, 2, 3]), np.array([4, 5, 6]), np.array([7, 8, 9])]
+        metadata = [
+            {
+                "doc_id": "doc1",
+                "chunk_index": 1,
+                "chunk_header": "Header 1",
+                "chunk_text": "Text 1",
+            },
+            {
+                "doc_id": "doc2",
+                "chunk_index": 2,
+                "chunk_header": "Header 2",
+                "chunk_text": "Text 2",
+            },
+            {
+                "doc_id": "doc3",
+                "chunk_index": 3,
+                "chunk_header": "Header 3",
+                "chunk_text": "Text 3",
+            },
+        ]
+        self.db.add_vectors(vectors, metadata)
+
+        query_vector = np.array([1, 2, 3])
+        results = self.db.search(query_vector, top_k=2)
+
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0]["metadata"]["doc_id"], "doc1")
+        self.assertAlmostEqual(results[0]["similarity"], 1.0)
+
+    def test_remove_document(self):
+        vectors = [np.array([1, 2, 3])]
+        metadata = [
+            {
+                "doc_id": "doc1",
+                "chunk_index": 1,
+                "chunk_header": "Header 1",
+                "chunk_text": "Text 1",
+            }
+        ]
+        self.db.add_vectors(vectors, metadata)
+
+        self.db.remove_document("doc1")
+        results = self.db.search(np.array([1, 2, 3]))
+        self.assertEqual(len(results), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Cassandra version `5.0` [added support for vectors](https://cassandra.apache.org/doc/latest/cassandra/getting-started/vector-search-quickstart.html), adding a connector here
- Added test cases for `CassandraVectorDB`
- Added `docker-compose.yaml` and `test.Dockerfile` to allow easy cross-platform testing and enable testing of Cassandra 
  - Run with `start.sh` or `start.ps1`