### PR TITLE
bug: fixed top_k bug in search_faiss and added test

### DIFF
--- a/dsrag/vector_db.py
+++ b/dsrag/vector_db.py
@@ -104,13 +104,16 @@ class BasicVectorDB(VectorDB):
         from faiss.contrib.exhaustive_search import knn
         import numpy as np
 
+        # Limit top_k to the number of vectors we have - Faiss doesn't automatically handle this
+        top_k = min(top_k, len(self.vectors))
+
         # faiss expects 2D arrays of vectors
         vectors_array = np.array(self.vectors).astype('float32').reshape(len(self.vectors), -1)
         query_vector_array = np.array(query_vector).astype('float32').reshape(1, -1)
         
         _, I = knn(query_vector_array, vectors_array, top_k) # I is a list of indices in the corpus_vectors array
         results = []
-        for i in I[0][:top_k]:
+        for i in I[0]:
             result = {
                 'metadata': self.metadata[i],
                 'similarity': cosine_similarity([query_vector], [self.vectors[i]])[0][0],

--- a/tests/unit/test_vector_db.py
+++ b/tests/unit/test_vector_db.py
@@ -128,6 +128,23 @@ class TestVectorDB(unittest.TestCase):
         # Make sure the storage directory does not exist
         self.assertFalse(os.path.exists(db.vector_storage_path))
 
+    def test__top_k_greater_than_num_vectors(self):
+        db = BasicVectorDB(self.kb_id, self.storage_directory)
+        vectors = [np.array([1, 0]), np.array([0, 1])]
+        metadata = [{'doc_id': '1', 'chunk_index': 0, 'chunk_header': 'Header1', 'chunk_text': 'Text1'},
+                    {'doc_id': '2', 'chunk_index': 1, 'chunk_header': 'Header2', 'chunk_text': 'Text2'}]
+        
+        db.add_vectors(vectors, metadata)
+        query_vector = np.array([1, 0])
+
+        db.use_faiss = True
+        results = db.search(query_vector, top_k=3)
+        self.assertEqual(len(results), 2)
+
+        db.use_faiss = False
+        results = db.search(query_vector, top_k=3)
+        self.assertEqual(len(results), 2)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
There was a bug in `search_faiss` (in the `BasicVectorDB` class) that caused unexpected behavior whenever `top_k > num_vectors`. This PR fixes that bug and adds a test for it.