### PR TITLE
bug: chunk header wasn't being properly passed in to reranker

### DIFF
--- a/dsrag/knowledge_base.py
+++ b/dsrag/knowledge_base.py
@@ -94,10 +94,8 @@ class KnowledgeBase:
 
     def add_document(self, doc_id: str, text: str, auto_context: bool = True, chunk_header: str = None, auto_context_guidance: str = ""):
         # verify that only one of auto_context and chunk_header is set
-        try:
-            assert auto_context != (chunk_header is not None)
-        except:
-            print ("Error in add_document: only one of auto_context and chunk_header can be set")
+        if auto_context and chunk_header:
+            print ("Warning in add_document: only one of auto_context and chunk_header should be set. Using the provided chunk_header.")
 
         # verify that the document does not already exist in the KB
         if doc_id in self.chunk_db.get_all_doc_ids():

--- a/dsrag/reranker.py
+++ b/dsrag/reranker.py
@@ -52,7 +52,7 @@ class CohereReranker(Reranker):
         for result in search_results:
             section_title = result['metadata'].get('section_title', '')
             section_title_addendum = f"From section: {section_title}\n" if section_title else ""
-            documents.append(f"[result['metadata']['chunk_header']]\n{section_title_addendum}{result['metadata']['chunk_text']}")
+            documents.append(f"{result['metadata']['chunk_header']}\n{section_title_addendum}{result['metadata']['chunk_text']}")
 
         reranked_results = self.client.rerank(model=self.model, query=query, documents=documents)
         results = reranked_results.results
@@ -92,7 +92,8 @@ class VoyageReranker(Reranker):
         for result in search_results:
             section_title = result['metadata'].get('section_title', '')
             section_title_addendum = f"From section: {section_title}\n" if section_title else ""
-            documents.append(f"[result['metadata']['chunk_header']]\n{section_title_addendum}{result['metadata']['chunk_text']}")
+            documents.append(f"{result['metadata']['chunk_header']}\n{section_title_addendum}{result['metadata']['chunk_text']}")
+        
         reranked_results = self.client.rerank(model=self.model, query=query, documents=documents)
         results = reranked_results.results
         reranked_indices = [result.index for result in results]


### PR DESCRIPTION
This PR fixes a bug in `rerank_search_results` (in both the `CohereReranker` and `VoyageReranker` classes) that caused the chunk header to not get included. It also fixes a small issue where a warning message was displayed when it shouldn't be in `add_document`.