### PR TITLE
GPT-4o Mini in semantic sectioning

### DIFF
--- a/dsrag/knowledge_base.py
+++ b/dsrag/knowledge_base.py
@@ -93,7 +93,21 @@ class KnowledgeBase:
         # delete the metadata file
         os.remove(self.get_metadata_path())
 
-    def add_document(self, doc_id: str, text: str, auto_context: bool = True, chunk_header: str = None, auto_context_guidance: str = "", semantic_sectioning: bool = False, min_length_for_chunking: int = 2000):
+    def add_document(self, doc_id: str, text: str, auto_context: bool = True, chunk_header: str = None, auto_context_guidance: str = "", semantic_sectioning: bool = False, semantic_sectioning_config: dict = {}, min_length_for_chunking: int = 2000):
+        """
+        Inputs:
+        - doc_id: should be descriptive, because it gets used as the document title in AutoContext
+        - text: the full text of the document
+        - auto_context: whether to use AutoContext to generate a chunk header
+        - chunk_header: if auto_context is False, the chunk header to use to provide document context
+        - auto_context_guidance: if auto_context is True, this is the guidance to provide to the AutoContext model
+        - semantic_sectioning: whether to use semantic sectioning to split the document into semantically cohesive chunks
+        - semantic_sectioning_config: a dictionary with configuration for the semantic sectioning model
+            - llm_provider: the LLM provider to use for semantic sectioning
+            - model: the LLM model to use for semantic sectioning
+        - min_length_for_chunking: the minimum length of text to allow chunking (measured in number of characters); if the text is shorter than this, it will be added as a single chunk
+        """
+        
         # verify that only one of auto_context and chunk_header is set
         if auto_context and chunk_header:
             print ("Warning in add_document: only one of auto_context and chunk_header should be set. Using the provided chunk_header.")
@@ -105,7 +119,9 @@ class KnowledgeBase:
         
         # do semantic sectioning
         if semantic_sectioning:
-            sections = get_sections(text)
+            llm_provider = semantic_sectioning_config.get('llm_provider', 'openai')
+            model = semantic_sectioning_config.get('model', 'gpt-4o-mini')
+            sections = get_sections(text, llm_provider=llm_provider, model=model)
         else:
             sections = [
                 {
@@ -125,7 +141,7 @@ class KnowledgeBase:
                     'section_title': section_title,
                 })
             else:
-                section_chunks = self.split_into_chunks(section_text)
+                section_chunks = self.split_into_chunks(section_text, )
                 for chunk in section_chunks:
                     chunks.append({
                         'chunk_text': chunk,
@@ -188,6 +204,9 @@ class KnowledgeBase:
         return self.embedding_model.get_embeddings(text, input_type)
     
     def split_into_chunks(self, text):
+        """
+        Note: it's very important that chunk overlap is set to 0 here, since results are created by concatenating chunks.
+        """
         text_splitter = RecursiveCharacterTextSplitter(chunk_size = self.kb_metadata['chunk_size'], chunk_overlap = 0, length_function = len)
         texts = text_splitter.create_documents([text])
         chunks = [text.page_content for text in texts]

--- a/dsrag/knowledge_base.py
+++ b/dsrag/knowledge_base.py
@@ -141,7 +141,7 @@ class KnowledgeBase:
                     'section_title': section_title,
                 })
             else:
-                section_chunks = self.split_into_chunks(section_text, )
+                section_chunks = self.split_into_chunks(section_text)
                 for chunk in section_chunks:
                     chunks.append({
                         'chunk_text': chunk,

--- a/dsrag/semantic_sectioning.py
+++ b/dsrag/semantic_sectioning.py
@@ -42,14 +42,14 @@ def get_document_with_lines(document_lines: List[str], start_line: int, max_char
             break
     return document_with_line_numbers, end_line
 
-def get_structured_document(document_with_line_numbers: str, start_line: int, end_line: int, provider: str = "anthropic") -> StructuredDocument:
+def get_structured_document(document_with_line_numbers: str, start_line: int, end_line: int, llm_provider: str, model: str) -> StructuredDocument:
     """
-    Note: The only models that work well for this task right now are GPT-4o and Claude 3.5 Sonnet, so that's why they're hardcoded here.
+    Note: This function relies on Instructor, which only supports certain model providers. That's why this function doesn't use the LLM abstract base class that is used elsewhere in the project.
     """
-    if provider == "anthropic":
+    if llm_provider == "anthropic":
         client = instructor.from_anthropic(Anthropic())
         return client.chat.completions.create(
-            model="claude-3-5-sonnet-20240620",
+            model=model,
             response_model=StructuredDocument,
             max_tokens=4000,
             temperature=0.0,
@@ -61,10 +61,10 @@ def get_structured_document(document_with_line_numbers: str, start_line: int, en
                 },
             ],
         )
-    elif provider == "openai":
+    elif llm_provider == "openai":
         client = instructor.from_openai(OpenAI())
         return client.chat.completions.create(
-            model="gpt-4o",
+            model=model,
             response_model=StructuredDocument,
             max_tokens=4000,
             temperature=0.0,
@@ -165,12 +165,13 @@ def partition_sections(sections, a, b):
 
     return sections
 
-def get_sections(document: str, max_characters: int = 20000, llm_provider: str = "anthropic") -> List[Dict[str, Any]]:
+def get_sections(document: str, max_characters: int = 20000, llm_provider: str = "openai", model: str = "gpt-4o-mini") -> List[Dict[str, Any]]:
     """
     Inputs
     - document: str - the text of the document
     - max_characters: int - the maximum number of characters to process in one call to the LLM
-    - llm_provider: str - the LLM provider to use (either "anthropic" or "openai", corresponding to GPT-4o and Claude 3.5 Sonnet, respectively)
+    - llm_provider: str - the LLM provider to use (either "anthropic" or "openai")
+    - model: str - the name of the LLM model to use
 
     Returns
     - all_sections: a list of dictionaries, each containing the following keys:
@@ -185,7 +186,7 @@ def get_sections(document: str, max_characters: int = 20000, llm_provider: str =
     all_sections = []
     for _ in range(max_iterations):
         document_with_line_numbers, end_line = get_document_with_lines(document_lines, start_line, max_characters)
-        structured_doc = get_structured_document(document_with_line_numbers, start_line, end_line, provider=llm_provider)
+        structured_doc = get_structured_document(document_with_line_numbers, start_line, end_line, llm_provider=llm_provider, model=model)
         new_sections = structured_doc.sections
         all_sections.extend(new_sections)
         

--- a/eval/semantic_sectioning_eval.py
+++ b/eval/semantic_sectioning_eval.py
@@ -11,6 +11,7 @@ script_dir = os.path.dirname(os.path.abspath(__file__))
 
 # Construct the absolute path to the dataset file
 file_path = os.path.join(script_dir, "../tests/data/levels_of_agi.pdf")
+#file_path = os.path.join(script_dir, "../tests/data/nike_2023_annual_report.txt")
 
 file_name = file_path.split("/")[-1].split(".")[0]
 print(f"Processing {file_name}...")
@@ -23,7 +24,7 @@ elif file_path.endswith(".txt"):
 else:
     raise ValueError("File must be a PDF or TXT file")
 
-segments = get_sections(document_text, max_characters=20000, llm_provider="openai")
+segments = get_sections(document_text, max_characters=20000, llm_provider="openai", model="gpt-4o-mini")
 
 """
 for s in segments[:100]:


### PR DESCRIPTION
Added support for using arbitrary model names in semantic sectioning (still only support OpenAI and Anthropic), and made GPT-4o Mini the new default.