### PR TITLE
Partition sections bug fix

### DIFF
--- a/dsrag/semantic_sectioning.py
+++ b/dsrag/semantic_sectioning.py
@@ -165,8 +165,8 @@ def partition_sections(sections, a, b):
                 completed_sections.append(Section(title="", start_index=sections[i-1].end_index+1, end_index=sections[i].start_index-1))
             elif sections[i].start_index <= sections[i-1].end_index:
                 # There is an overlap between sections[i-1] and sections[i]
-                completed_sections[i-1].end_index = sections[i].start_index - 1
-                completed_sections[i-1].title = ""
+                completed_sections[-1].end_index = sections[i].start_index - 1
+                completed_sections[-1].title = ""
             # Always add the current iteration's section
             completed_sections.append(sections[i])
 

--- a/tests/unit/test_semantic_sectioning.py
+++ b/tests/unit/test_semantic_sectioning.py
@@ -104,9 +104,27 @@ class TestPartitionSections(unittest.TestCase):
         ]
         result = partition_sections(sections, a, b)
         assert result == expected, f"Expected {expected}, but got {result}"
+    
+    # Test case 7: Gap, then overlapping section
+    def test__gap_then_overlapping_section(self):
+        sections = [
+            Section(title="Introduction", start_index=0, end_index=3),
+            Section(title="Body", start_index=7, end_index=11),
+            Section(title="Conclusion", start_index=10, end_index=14)
+        ]
+        a = 0
+        b = 14
+        expected = [
+            Section(title="Introduction", start_index=0, end_index=3),
+            Section(title="", start_index=4, end_index=6),
+            Section(title="", start_index=7, end_index=9),
+            Section(title="Conclusion", start_index=10, end_index=14)
+        ]
+        result = partition_sections(sections, a, b)
+        assert result == expected, f"Expected {expected}, but got {result}"
 
-    # Test case 7: Overlapping and gap
-    def test__overlapping_and_gap(self):
+    # Test case 8: Overlapping then gap
+    def test__overlapping_then_gap(self):
         sections = [
             Section(title="Introduction", start_index=0, end_index=6),
             Section(title="Body", start_index=5, end_index=9)
@@ -121,7 +139,7 @@ class TestPartitionSections(unittest.TestCase):
         result = partition_sections(sections, a, b)
         assert result == expected, f"Expected {expected}, but got {result}"
 
-    # Test case 8: One section is a subset of another section
+    # Test case 9: One section is a subset of another section
     def test__subset_sections(self):
         sections = [
             Section(title="Introduction", start_index=0, end_index=10),
@@ -136,7 +154,7 @@ class TestPartitionSections(unittest.TestCase):
         result = partition_sections(sections, a, b)
         assert result == expected, f"Expected {expected}, but got {result}"
 
-    # Test case 9: Sections with the same start and end indices
+    # Test case 10: Sections with the same start and end indices
     def test__same_indices(self):
         sections = [
             Section(title="Introduction", start_index=0, end_index=10),
@@ -151,7 +169,7 @@ class TestPartitionSections(unittest.TestCase):
         result = partition_sections(sections, a, b)
         assert result == expected, f"Expected {expected}, but got {result}"
 
-    # Test case 10: Sections completely outside the range [a, b]
+    # Test case 11: Sections completely outside the range [a, b]
     def test__sections_outside(self):
         sections = [
             Section(title="Outside", start_index=15, end_index=20)
@@ -164,7 +182,7 @@ class TestPartitionSections(unittest.TestCase):
         result = partition_sections(sections, a, b)
         assert result == expected, f"Expected {expected}, but got {result}"
 
-    # Test case 11: Sections with invalid indices
+    # Test case 12: Sections with invalid indices
     def test__invalid_indices(self):
         sections = [
             Section(title="Invalid", start_index=10, end_index=9)


### PR DESCRIPTION
Bug fix to use `-1` index instead of `i-1` when creating the `completed_sections` array inside of `partition_sections`, since `i` is the index of the `sections` array, not `completed_sections`. This caused a bug if there was ever a gap in the sections, and then an overlapping section.
Also added a test case for this scenario.