### PR TITLE
AutoContext refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,10 @@ The Reranker components define the reranker. This is used after the vector datab
 
 The currently available options are:
 - `CohereReranker`
+- `VoyageReranker`
 
 #### LLM
-This defines the LLM to be used for document summarization in AutoContext.
+This defines the LLM to be used for document title generation, document summarization, and section summarization in AutoContext.
 
 The currently available options are:
 - `OpenAIChatAPI`
@@ -131,26 +132,26 @@ There are two config dictionaries that can be passed in to `add_document` (`auto
 Default values will be used for any parameters not provided in these dictionaries, so if you just want to alter one or two parameters there's no need to send in the full dictionary.
 
 auto_context_config
-    - use_generated_title: bool - whether to use an LLM-generated title if no title is provided (default is True)
-    - document_title_guidance: str - guidance for generating the document title
-    - get_document_summary: bool - whether to get a document summary (default is True)
-    - document_summarization_guidance: str
-    - get_section_summaries: bool - whether to get section summaries (default is False)
-    - section_summarization_guidance: str
+- use_generated_title: bool - whether to use an LLM-generated title if no title is provided (default is True)
+- document_title_guidance: str - guidance for generating the document title
+- get_document_summary: bool - whether to get a document summary (default is True)
+- document_summarization_guidance: str
+- get_section_summaries: bool - whether to get section summaries (default is False)
+- section_summarization_guidance: str
 
 semantic_sectioning_config
-    - llm_provider: the LLM provider to use for semantic sectioning - only "openai" and "anthropic" are supported at the moment
-    - model: the LLM model to use for semantic sectioning
-    - use_semantic_sectioning: if False, semantic sectioning will be skipped (default is True)
+- llm_provider: the LLM provider to use for semantic sectioning - only "openai" and "anthropic" are supported at the moment
+- model: the LLM model to use for semantic sectioning
+- use_semantic_sectioning: if False, semantic sectioning will be skipped (default is True)
 
 rse_params
-    - max_length: maximum length of a segment, measured in number of chunks
-    - overall_max_length: maximum length of all segments combined, measured in number of chunks
-    - minimum_value: minimum value of a segment, measured in relevance value
-    - irrelevant_chunk_penalty: float between 0 and 1
-    - overall_max_length_extension: the maximum length of all segments combined will be increased by this amount for each additional query beyond the first
-    - decay_rate
-    - top_k_for_document_selection: the number of documents to consider
+- max_length: maximum length of a segment, measured in number of chunks
+- overall_max_length: maximum length of all segments combined, measured in number of chunks
+- minimum_value: minimum value of a segment, measured in relevance value
+- irrelevant_chunk_penalty: float between 0 and 1
+- overall_max_length_extension: the maximum length of all segments combined will be increased by this amount for each additional query beyond the first
+- decay_rate
+- top_k_for_document_selection: the number of documents to consider
 
 ## Document upload flow
 Documents -> semantic sectioning -> AutoContext -> chunking -> embedding -> chunk and vector database upsert

--- a/dsrag/auto_context.py
+++ b/dsrag/auto_context.py
@@ -109,8 +109,9 @@ def get_chunk_header(document_title: str = "", document_summary: str = "", secti
 
 def get_segment_header(document_title: str = "", document_summary: str = ""):
     """
-    The segment header is what gets prepended to each segment (i.e. search result). This provides context to the LLM about the segment.
+    The segment header is what gets prepended to each segment (i.e. search result). This provides context to the LLM about the segment. The segment header only contains document-level information. Section-level information is not needed here, because either the segment will be large enough to not need section-level context, or the it will be a chunk where the section-level context isn't relevant to the query (because otherwise more of the section would have been included in the segment).
     """
     segment_header = ""
     if document_title:
         segment_header += f"Document context: the following excerpt is from a document titled '{document_title}'. {document_summary}"
+    return segment_header

--- a/dsrag/auto_context.py
+++ b/dsrag/auto_context.py
@@ -1,7 +1,7 @@
 from dsrag.llm import LLM
 import tiktoken
 
-PROMPT = """
+DOCUMENT_SUMMARIZATION_PROMPT = """
 INSTRUCTIONS
 What is the following document, and what is it about? 
 
@@ -11,18 +11,35 @@ You MUST include the name of the document in your response (if available), as th
 
 Your response should take the form of "This document is: X, and is about: Y". For example, if the document is a book about the history of the United States called A People's History of the United States, your response might be "This document is: A People's History of the United States, and is about the history of the United States, covering the period from 1776 to the present day." If the document is the 2023 Form 10-K for Apple Inc., your response might be "This document is: Apple Inc. FY2023 Form 10-K, and is about: the financial performance and operations of Apple Inc. during the fiscal year 2023."
 
-{auto_context_guidance}
+{document_summarization_guidance}
 
 {truncation_message}
 
 DOCUMENT
-filename: {document_title}
+File name: {document_title}
 
-{document}
+{document_text}
 """.strip()
 
 TRUNCATION_MESSAGE = """
 Also note that the document text provided below is just the first ~4500 words of the document. Your response should still pertain to the entire document, not just the text provided below.
+""".strip()
+
+SECTION_SUMMARIZATION_PROMPT = """
+INSTRUCTIONS
+What is the following section about? 
+
+Your response should be a single sentence, and it shouldn't be an excessively long sentence. DO NOT respond with anything else.
+
+Your response should take the form of "This section is about: X". For example, if the section is a balance sheet from a financial report about Apple, your response might be "This section is about: the financial position of Apple as of the end of the fiscal year." If the section is a chapter from a book on the history of the United States, and this chapter covers the Civil War, your response might be "This section is about: the causes and consequences of the American Civil War."
+
+{section_summarization_guidance}
+
+SECTION
+Document name: {document_title}
+Section name: {section_title}
+
+{section_text}
 """.strip()
 
 def truncate_content(content: str, max_tokens: int):
@@ -31,21 +48,42 @@ def truncate_content(content: str, max_tokens: int):
     truncated_tokens = tokens[:max_tokens]
     return TOKEN_ENCODER.decode(truncated_tokens), min(len(tokens), max_tokens)
 
-def get_document_context(auto_context_model: LLM, text: str, document_title: str, auto_context_guidance: str = ""):
+def get_document_summary(auto_context_model: LLM, document_text: str, document_title: str, document_summarization_guidance: str = ""):
     # truncate the content if it's too long
     max_content_tokens = 6000 # if this number changes, also update the truncation message above
-    text, num_tokens = truncate_content(text, max_content_tokens)
+    document_text, num_tokens = truncate_content(document_text, max_content_tokens)
     if num_tokens < max_content_tokens:
         truncation_message = ""
     else:
         truncation_message = TRUNCATION_MESSAGE
     
-    # get document context
-    prompt = PROMPT.format(auto_context_guidance=auto_context_guidance, document=text, document_title=document_title, truncation_message=truncation_message)
+    # get document summary
+    prompt = DOCUMENT_SUMMARIZATION_PROMPT.format(document_summarization_guidance=document_summarization_guidance, document_text=document_text, document_title=document_title, truncation_message=truncation_message)
     chat_messages = [{"role": "user", "content": prompt}]
-    document_context = auto_context_model.make_llm_call(chat_messages)
-    return document_context
+    document_summary = auto_context_model.make_llm_call(chat_messages)
+    return document_summary
 
-def get_chunk_header(file_name, document_context):
-    chunk_header = f"Document context: the following excerpt is from {file_name}. {document_context}"
+def get_section_summary(auto_context_model: LLM, text: str, document_title: str, section_title: str, section_summarization_guidance: str = ""):
+    prompt = SECTION_SUMMARIZATION_PROMPT.format(section_summarization_guidance=section_summarization_guidance, section_text=text, document_title=document_title, section_title=section_title)
+    chat_messages = [{"role": "user", "content": prompt}]
+    section_summary = auto_context_model.make_llm_call(chat_messages)
+    return section_summary
+
+def get_chunk_header(document_title: str = "", document_summary: str = "", section_title: str = "", section_summary: str = ""):
+    """
+    The chunk header is what gets prepended to each chunk before embedding or reranking. At the very least, it should contain the document title.
+    """
+    chunk_header = ""
+    if document_title:
+        chunk_header += f"Document context: the following excerpt is from a document titled '{document_title}'. {document_summary}"
+    if section_title:
+        chunk_header += f"\nSection context: this excerpt is from the section titled '{section_title}'. {section_summary}"
     return chunk_header
+
+def get_segment_header(document_title: str = "", document_summary: str = ""):
+    """
+    The segment header is what gets prepended to each segment (i.e. search result). This provides context to the LLM about the segment.
+    """
+    segment_header = ""
+    if document_title:
+        segment_header += f"Document context: the following excerpt is from a document titled '{document_title}'. {document_summary}"

--- a/dsrag/chunk_db.py
+++ b/dsrag/chunk_db.py
@@ -45,16 +45,27 @@ class ChunkDB(ABC):
         pass
 
     @abstractmethod
-    def get_chunk_header(self, doc_id: str, chunk_index: int) -> str:
+    def get_document_title(self, doc_id: str, chunk_index: int) -> str:
         """
-        Retrieve the header of a specific chunk from a given document ID.
+        Retrieve the document title of a specific chunk from a given document ID.
         """
         pass
 
-    @abstractmethod
+    def get_document_summary(self, doc_id: str, chunk_index: int) -> str:
+        """
+        Retrieve the document summary of a specific chunk from a given document ID.
+        """
+        pass
+
     def get_section_title(self, doc_id: str, chunk_index: int) -> str:
         """
         Retrieve the section title of a specific chunk from a given document ID.
+        """
+        pass
+
+    def get_section_summary(self, doc_id: str, chunk_index: int) -> str:
+        """
+        Retrieve the section summary of a specific chunk from a given document ID.
         """
         pass
 
@@ -98,15 +109,34 @@ class BasicChunkDB(ChunkDB):
             return self.data[doc_id][chunk_index]['chunk_text']
         return None
 
-    def get_chunk_header(self, doc_id: str, chunk_index: int) -> str:
+    def get_document_title(self, doc_id: str, chunk_index: int) -> str:
         if doc_id in self.data and chunk_index in self.data[doc_id]:
-            return self.data[doc_id][chunk_index]['chunk_header']
+            if 'document_title' in self.data[doc_id][chunk_index]:
+                return self.data[doc_id][chunk_index]['document_title']
+            else:
+                return ""
+        return None
+    
+    def get_document_summary(self, doc_id: str, chunk_index: int) -> str:
+        if doc_id in self.data and chunk_index in self.data[doc_id]:
+            if 'document_summary' in self.data[doc_id][chunk_index]:
+                return self.data[doc_id][chunk_index]['document_summary']
+            else:
+                return ""
         return None
     
     def get_section_title(self, doc_id: str, chunk_index: int) -> str:
         if doc_id in self.data and chunk_index in self.data[doc_id]:
             if 'section_title' in self.data[doc_id][chunk_index]:
                 return self.data[doc_id][chunk_index]['section_title']
+            else:
+                return ""
+        return None
+    
+    def get_section_summary(self, doc_id: str, chunk_index: int) -> str:
+        if doc_id in self.data and chunk_index in self.data[doc_id]:
+            if 'section_summary' in self.data[doc_id][chunk_index]:
+                return self.data[doc_id][chunk_index]['section_summary']
             else:
                 return ""
         return None

--- a/dsrag/create_kb.py
+++ b/dsrag/create_kb.py
@@ -3,7 +3,7 @@ from dsrag.knowledge_base import KnowledgeBase
 import os
 import time
 
-def create_kb_from_directory(kb_id: str, directory: str, title: str = None, description: str = "", language: str = 'en', auto_context: bool = True, auto_context_guidance: str = ""):
+def create_kb_from_directory(kb_id: str, directory: str, title: str = None, description: str = "", language: str = 'en'):
     """
     - kb_id is the name of the knowledge base
     - directory is the absolute path to the directory containing the documents
@@ -33,7 +33,7 @@ def create_kb_from_directory(kb_id: str, directory: str, title: str = None, desc
                         with open(file_path, 'r') as f:
                             text = f.read()
 
-                    kb.add_document(clean_file_path, text, auto_context=auto_context, auto_context_guidance=auto_context_guidance)
+                    kb.add_document(doc_id=clean_file_path, text=text)
                     time.sleep(1) # pause for 1 second to avoid hitting API rate limits
                 except:
                     print (f"Error reading {file_name}")
@@ -44,7 +44,7 @@ def create_kb_from_directory(kb_id: str, directory: str, title: str = None, desc
     
     return kb
 
-def create_kb_from_file(kb_id: str, file_path: str, title: str = None, description: str = "", language: str = 'en', auto_context: bool = True, auto_context_guidance: str = ""):
+def create_kb_from_file(kb_id: str, file_path: str, title: str = None, description: str = "", language: str = 'en'):
     """
     - kb_id is the name of the knowledge base
     - file_path is the absolute path to the file containing the documents
@@ -74,7 +74,7 @@ def create_kb_from_file(kb_id: str, file_path: str, title: str = None, descripti
             with open(file_path, 'r') as f:
                 text = f.read()
 
-        kb.add_document(clean_file_path, text, auto_context=auto_context, auto_context_guidance=auto_context_guidance)
+        kb.add_document(doc_id=clean_file_path, text=text)
     else:
         print (f"Unsupported file type: {file_name}")
         return

--- a/dsrag/knowledge_base.py
+++ b/dsrag/knowledge_base.py
@@ -165,7 +165,7 @@ class KnowledgeBase:
                     'section_summary': section_summary,
                 })
             else:
-                section_chunks = self.split_into_chunks(section_text)
+                section_chunks = self.split_into_chunks(section_text, chunk_size=chunk_size)
                 for chunk in section_chunks:
                     chunks.append({
                         'chunk_text': chunk,

--- a/dsrag/llm.py
+++ b/dsrag/llm.py
@@ -32,7 +32,7 @@ class LLM(ABC):
         pass
 
 class OpenAIChatAPI(LLM):
-    def __init__(self, model: str = "gpt-3.5-turbo", temperature: float = 0.2, max_tokens: int = 1000):
+    def __init__(self, model: str = "gpt-4o-mini", temperature: float = 0.2, max_tokens: int = 1000):
         from openai import OpenAI
         self.client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
         self.model = model

--- a/dsrag/reranker.py
+++ b/dsrag/reranker.py
@@ -50,9 +50,7 @@ class CohereReranker(Reranker):
         """
         documents = []
         for result in search_results:
-            section_title = result['metadata'].get('section_title', '')
-            section_title_addendum = f"From section: {section_title}\n" if section_title else ""
-            documents.append(f"{result['metadata']['chunk_header']}\n{section_title_addendum}{result['metadata']['chunk_text']}")
+            documents.append(f"{result['metadata']['chunk_header']}\n\n{result['metadata']['chunk_text']}")
 
         reranked_results = self.client.rerank(model=self.model, query=query, documents=documents)
         results = reranked_results.results
@@ -90,9 +88,7 @@ class VoyageReranker(Reranker):
         """
         documents = []
         for result in search_results:
-            section_title = result['metadata'].get('section_title', '')
-            section_title_addendum = f"From section: {section_title}\n" if section_title else ""
-            documents.append(f"{result['metadata']['chunk_header']}\n{section_title_addendum}{result['metadata']['chunk_text']}")
+            documents.append(f"{result['metadata']['chunk_header']}\n\n{result['metadata']['chunk_text']}")
         
         reranked_results = self.client.rerank(model=self.model, query=query, documents=documents)
         results = reranked_results.results

--- a/eval/rse_eval.py
+++ b/eval/rse_eval.py
@@ -23,7 +23,14 @@ def test_create_kb_from_file():
     #kb = create_kb_from_file(kb_id, file_path)
     kb = KnowledgeBase(kb_id=kb_id, exists_ok=False)
     text = extract_text_from_pdf(file_path)
-    kb.add_document(file_path, text)
+
+    auto_context_config = {
+        'use_generated_title': True,
+        'get_document_summary': True,
+        'get_section_summaries': True,
+    }
+
+    kb.add_document(file_path, text, auto_context_config=auto_context_config)
 
 def cleanup():
     kb = KnowledgeBase(kb_id="levels_of_agi", exists_ok=True)
@@ -35,13 +42,11 @@ This script is for doing qualitative evaluation of RSE
 
 
 if __name__ == "__main__":
-    """
     # create the KnowledgeBase
     try:
         test_create_kb_from_file()
     except ValueError as e:
         print(e)
-    """
 
     rse_params = {
         'max_length': 20,
@@ -78,7 +83,7 @@ if __name__ == "__main__":
     
     print ()
     for segment in relevant_segments:
-        print (len(segment["text"]))
+        #print (len(segment["text"]))
         #print (segment["score"])
-        #print (segment["text"])
+        print (segment["text"])
         print ("---\n")

--- a/examples/dsRAG_motivation.ipynb
+++ b/examples/dsRAG_motivation.ipynb
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -63,7 +63,6 @@
     "# set API keys\n",
     "import os\n",
     "os.environ[\"OPENAI_API_KEY\"] = \"\"\n",
-    "os.environ[\"ANTHROPIC_API_KEY\"] = \"\"\n",
     "os.environ[\"CO_API_KEY\"] = \"\""
    ]
   },
@@ -78,7 +77,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [
     {
@@ -141,7 +140,7 @@
     "\n",
     "# add to knowledge base\n",
     "#kb = KnowledgeBase(kb_id=kb_id, exists_ok=False, storage_directory='example_kb_data') # create a new knowledge base\n",
-    "#kb.add_document(doc_id=doc_id, text=document_text, auto_context=False, semantic_sectioning=True) # add the document to the knowledge base"
+    "#kb.add_document(doc_id=doc_id, text=document_text) # add the document to the knowledge base"
    ]
   },
   {
@@ -154,7 +153,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
     {
@@ -167,12 +166,11 @@
     {
      "data": {
       "text/plain": [
-       "{'chunk_header': '',\n",
-       " 'section_title': 'Form 10-K Cover Page and Company Information',\n",
+       "{'section_title': 'Form 10-K Cover Page and Company Information',\n",
        " 'chunk_text': \"FORM 10-K FORM 10-KUNITED STATES\\nSECURITIES AND EXCHANGE COMMISSION\\nWashington, D.C. 20549\\nFORM 10-K \\n(Mark One)\\n☑ ANNUAL REPORT PURSUANT TO SECTION 13 OR 15(D) OF THE SECURITIES EXCHANGE ACT OF 1934\\nFOR THE FISCAL YEAR ENDED MAY 31, 2023 \\nOR\\n☐TRANSITION REPORT PURSUANT TO SECTION 13 OR 15(D) OF THE SECURITIES EXCHANGE ACT OF 1934\\nFOR THE TRANSITION PERIOD FROM TO .\\nCommission File No. 1-10635 \\nNIKE, Inc. \\n(Exact name of Registrant as specified in its charter)\\nOregon 93-0584541\\n(State or other jurisdiction of incorporation) (IRS Employer Identification No.)\\nOne Bowerman Drive, Beaverton, Oregon 97005-6453 \\n(Address of principal executive offices and zip code)\\n(503) 671-6453 \\n(Registrant's telephone number, including area code)\\nSECURITIES REGISTERED PURSUANT TO SECTION 12(B) OF THE ACT:\"}"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -187,7 +185,6 @@
     "chunks = []\n",
     "for i in range(num_chunks):\n",
     "    chunk = {\n",
-    "        \"chunk_header\": kb.chunk_db.get_chunk_header(doc_id, i),\n",
     "        \"section_title\": kb.chunk_db.get_section_title(doc_id, i),\n",
     "        \"chunk_text\": kb.chunk_db.get_chunk_text(doc_id, i),\n",
     "    }\n",
@@ -207,7 +204,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [
     {
@@ -394,7 +391,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -443,7 +440,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [
     {
@@ -497,7 +494,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [
     {
@@ -536,7 +533,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [
     {
@@ -549,10 +546,10 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.collections.PathCollection at 0x7f88a428cdf0>"
+       "<matplotlib.collections.PathCollection at 0x7f88704caa00>"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 40,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -620,7 +617,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [
     {
@@ -790,6 +787,7 @@
    ],
    "source": [
     "# be sure you're using the Nike 10-K KB for these next few cells, as we'll be focusing on a single example query for that document\n",
+    "\n",
     "query = \"Nike stock-based compensation expenses\"\n",
     "similarity_scores, chunk_values = rerank_documents(query, documents)\n",
     "\n",
@@ -829,16 +827,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.collections.PathCollection at 0x7f8880646c10>"
+       "<matplotlib.collections.PathCollection at 0x7f8870495a30>"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 42,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -876,7 +874,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [
     {

--- a/tests/integration/test_chunk_and_segment_headers.py
+++ b/tests/integration/test_chunk_and_segment_headers.py
@@ -1,0 +1,101 @@
+import sys
+import os
+import unittest
+
+# add ../../ to sys.path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
+
+from dsrag.document_parsing import extract_text_from_pdf
+from dsrag.knowledge_base import KnowledgeBase
+
+
+class TestChunkAndSegmentHeaders(unittest.TestCase):    
+    def test_all_context_included(self):
+        self.cleanup() # delete the KnowledgeBase object if it exists so we can start fresh
+        
+        # Get the absolute path of the script file
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+
+        # Construct the absolute path to the dataset file
+        file_path = os.path.join(script_dir, "../data/levels_of_agi.pdf")
+
+        # extract text from the pdf
+        text = extract_text_from_pdf(file_path)
+        
+        kb_id = "levels_of_agi"
+        kb = KnowledgeBase(kb_id=kb_id, exists_ok=False)
+
+        # set configuration for auto context and semantic sectioning and add the document to the KnowledgeBase
+        auto_context_config = {
+            'use_generated_title': True,
+            'get_document_summary': True,
+            'get_section_summaries': True,
+        }
+        semantic_sectioning_config = {
+            'use_semantic_sectioning': True,
+        }
+        kb.add_document(doc_id="doc_1", text=text, auto_context_config=auto_context_config, semantic_sectioning_config=semantic_sectioning_config)
+
+        # verify that the chunk headers are as expected by running searches and looking at the chunk_header in the results
+        search_query = "What are the Levels of AGI and why were they defined this way?"
+        search_results = kb.search(search_query, top_k=1)
+        chunk_header = search_results[0]['metadata']['chunk_header']
+        print (f"\nCHUNK HEADER\n{chunk_header}")
+        
+        # verify that the segment headers are as expected
+        segment_header = kb.get_segment_header(doc_id="doc_1", chunk_index=0)
+
+        assert "Section context" in chunk_header
+        assert "AGI" in segment_header
+
+        # delete the KnowledgeBase object
+        kb.delete()
+
+    def test_no_context_included(self):
+        self.cleanup() # delete the KnowledgeBase object if it exists so we can start fresh
+        
+        # Get the absolute path of the script file
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+
+        # Construct the absolute path to the dataset file
+        file_path = os.path.join(script_dir, "../data/levels_of_agi.pdf")
+
+        # extract text from the pdf
+        text = extract_text_from_pdf(file_path)
+        
+        kb_id = "levels_of_agi"
+        kb = KnowledgeBase(kb_id=kb_id, exists_ok=False)
+
+        # set configuration for auto context and semantic sectioning and add the document to the KnowledgeBase
+        auto_context_config = {
+            'use_generated_title': False,
+            'get_document_summary': False,
+            'get_section_summaries': False,
+        }
+        semantic_sectioning_config = {
+            'use_semantic_sectioning': False,
+        }
+        kb.add_document(doc_id="doc_1", text=text, auto_context_config=auto_context_config, semantic_sectioning_config=semantic_sectioning_config)
+
+        # verify that the chunk headers are as expected by running searches and looking at the chunk_header in the results
+        search_query = "What are the Levels of AGI and why were they defined this way?"
+        search_results = kb.search(search_query, top_k=1)
+        chunk_header = search_results[0]['metadata']['chunk_header']
+        print (f"\nCHUNK HEADER\n{chunk_header}")
+        
+        # verify that the segment headers are as expected
+        segment_header = kb.get_segment_header(doc_id="doc_1", chunk_index=0)
+
+        assert "Section context" not in chunk_header
+        assert "AGI" not in segment_header
+
+        # delete the KnowledgeBase object
+        kb.delete()
+        
+
+    def cleanup(self):
+        kb = KnowledgeBase(kb_id="levels_of_agi", exists_ok=True)
+        kb.delete()
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_auto_context.py
+++ b/tests/unit/test_auto_context.py
@@ -69,7 +69,12 @@ class TestAutoContext(unittest.TestCase):
         assert "NIKE, Inc. Annual Report on Form 10-K for the Fiscal Year Ended May 31, 2023" in chunk_header
 
     def test__get_segment_header(self):
-        pass
+        document_title = "NIKE, Inc. Annual Report on Form 10-K for the Fiscal Year Ended May 31, 2023"
+        document_summary = "This document is about: the financial performance, business operations, and strategic initiatives of NIKE, Inc. for the fiscal year ended May 31, 2023, as detailed in its Annual Report on Form 10-K."
+        segment_header = get_segment_header(document_title, document_summary)
+        assert "Document context" in segment_header
+        assert "NIKE, Inc. Annual Report on Form 10-K for the Fiscal Year Ended May 31, 2023" in segment_header
+        assert "financial performance" in segment_header
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_auto_context.py
+++ b/tests/unit/test_auto_context.py
@@ -1,0 +1,75 @@
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+from dsrag.auto_context import get_document_title, get_document_summary, get_section_summary, get_chunk_header, get_segment_header
+from dsrag.llm import OpenAIChatAPI
+
+SECTION_TEXT = """
+PRODUCT RESEARCH, DESIGN AND DEVELOPMENT
+We believe our research, design and development efforts are key factors in our success. Technical innovation in the design and 
+manufacturing process of footwear, apparel and athletic equipment receives continued emphasis as we strive to produce 
+products that help to enhance athletic performance, reduce injury and maximize comfort, while decreasing our environmental 
+impact.
+In addition to our own staff of specialists in the areas of biomechanics, chemistry, exercise physiology, engineering, digital 
+technologies, industrial design, sustainability and related fields, we also utilize research committees and advisory boards made 
+up of athletes, coaches, trainers, equipment managers, orthopedists, podiatrists, physicians and other experts who consult with 
+us and review certain designs, materials and concepts for product and manufacturing, design and other process improvements 
+and compliance with product safety regulations around the world. E mployee athletes, athletes engaged under sports marketing 
+contracts and other athletes wear-test and evaluate products during the design and development process.
+As we continue to develop new technologies, we are simultaneously focused on the design of innovative products and 
+experiences incorporating such technologies throughout our product categories and consumer applications. Using market 
+intelligence and research, our various design teams identify opportunities to leverage new technologies in existing categories to 
+respond to consumer preferences. The proliferation of Nike Air, Zoom, Free, Dri-FIT, Flyknit, FlyEase, ZoomX, Air Max, React and 
+Forward technologies, among others, typifies our dedication to designing innovative products.
+"""
+
+
+class TestAutoContext(unittest.TestCase):
+    def test__get_document_title(self):
+        auto_context_model = OpenAIChatAPI(model="gpt-4o-mini")
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+        file_path = os.path.join(script_dir, "../data/nike_2023_annual_report.txt")
+        with open(file_path, "r") as f:
+            document_text = f.read()
+        document_title_guidance = "Make sure the title is nice and human readable."
+        document_title = get_document_title(auto_context_model, document_text, document_title_guidance=document_title_guidance)
+        assert "nike" in document_title.lower()
+
+    def test__get_document_summary(self):
+        document_title = "NIKE, Inc. Annual Report on Form 10-K for the Fiscal Year Ended May 31, 2023"
+        auto_context_model = OpenAIChatAPI(model="gpt-4o-mini")
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+        file_path = os.path.join(script_dir, "../data/nike_2023_annual_report.txt")
+        with open(file_path, "r") as f:
+            document_text = f.read()
+        document_summarization_guidance = "Make sure the summary is concise and informative."
+        document_summary = get_document_summary(auto_context_model, document_text, document_title, document_summarization_guidance=document_summarization_guidance)
+        assert "nike" in document_summary.lower()
+
+    def test__get_section_summary(self):
+        document_title = "NIKE, Inc. Annual Report on Form 10-K for the Fiscal Year Ended May 31, 2023"
+        section_title = "Product Research, Design and Development"
+        auto_context_model = OpenAIChatAPI(model="gpt-4o-mini")
+        section_text = SECTION_TEXT
+        section_summarization_guidance = "Make sure the summary is concise and informative."
+        section_summary = get_section_summary(auto_context_model, section_text, document_title, section_title, section_summarization_guidance=section_summarization_guidance)
+        assert "product" in section_summary.lower()
+
+    def test__get_chunk_header(self):
+        document_title = "NIKE, Inc. Annual Report on Form 10-K for the Fiscal Year Ended May 31, 2023"
+        document_summary = "This document is about: the financial performance, business operations, and strategic initiatives of NIKE, Inc. for the fiscal year ended May 31, 2023, as detailed in its Annual Report on Form 10-K."
+        section_title = "Product Research, Design and Development"
+        section_summary = "This section is about: Nike's commitment to product research, design, and development aimed at enhancing athletic performance and sustainability through technical innovation and expert collaboration."
+        chunk_header = get_chunk_header(document_title, document_summary, section_title, section_summary)
+        assert "Document context" in chunk_header
+        assert "Section context" in chunk_header
+        assert "Product Research, Design and Development" in chunk_header
+        assert "NIKE, Inc. Annual Report on Form 10-K for the Fiscal Year Ended May 31, 2023" in chunk_header
+
+    def test__get_segment_header(self):
+        pass
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_chunk_db.py
+++ b/tests/unit/test_chunk_db.py
@@ -30,28 +30,58 @@ class TestChunkDB(unittest.TestCase):
         db = BasicChunkDB(self.kb_id, self.storage_directory)
         doc_id = 'doc1'
         chunks = {
-            0: {'chunk_header': 'Header 1', 'chunk_text': 'Content of chunk 1'},
-            1: {'chunk_header': 'Header 2', 'chunk_text': 'Content of chunk 2'}
+            0: {'chunk_text': 'Content of chunk 1', 'document_title': 'Title of document 1', 'document_summary': 'Summary of document 1', 'section_title': 'Section title 1', 'section_summary': 'Section summary 1'},
+            1: {'chunk_text': 'Content of chunk 2', 'document_title': 'Title of document 2', 'document_summary': 'Summary of document 2', 'section_title': 'Section title 2', 'section_summary': 'Section summary 2'},
         }
         db.add_document(doc_id, chunks)
         retrieved_chunk = db.get_chunk_text(doc_id, 0)
         self.assertEqual(retrieved_chunk, chunks[0]['chunk_text'])
 
-    def test__get_chunk_header(self):
+    def test__get_document_title(self):
         db = BasicChunkDB(self.kb_id, self.storage_directory)
         doc_id = 'doc1'
         chunks = {
-            0: {'chunk_header': 'Header 1', 'chunk_text': 'Content of chunk 1'}
+            0: {'document_title': 'Title 1', 'chunk_text': 'Content of chunk 1'}
         }
         db.add_document(doc_id, chunks)
-        header = db.get_chunk_header(doc_id, 0)
-        self.assertEqual(header, 'Header 1')
+        title = db.get_document_title(doc_id, 0)
+        self.assertEqual(title, 'Title 1')
+
+    def test__get_document_summary(self):
+        db = BasicChunkDB(self.kb_id, self.storage_directory)
+        doc_id = 'doc1'
+        chunks = {
+            0: {'document_summary': 'Summary 1', 'chunk_text': 'Content of chunk 1'}
+        }
+        db.add_document(doc_id, chunks)
+        summary = db.get_document_summary(doc_id, 0)
+        self.assertEqual(summary, 'Summary 1')
+
+    def test__get_section_title(self):
+        db = BasicChunkDB(self.kb_id, self.storage_directory)
+        doc_id = 'doc1'
+        chunks = {
+            0: {'section_title': 'Title 1', 'chunk_text': 'Content of chunk 1'}
+        }
+        db.add_document(doc_id, chunks)
+        title = db.get_section_title(doc_id, 0)
+        self.assertEqual(title, 'Title 1')
+
+    def test__get_section_summary(self):
+        db = BasicChunkDB(self.kb_id, self.storage_directory)
+        doc_id = 'doc1'
+        chunks = {
+            0: {'section_summary': 'Summary 1', 'chunk_text': 'Content of chunk 1'}
+        }
+        db.add_document(doc_id, chunks)
+        summary = db.get_section_summary(doc_id, 0)
+        self.assertEqual(summary, 'Summary 1')
 
     def test__remove_document(self):
         db = BasicChunkDB(self.kb_id, self.storage_directory)
         doc_id = 'doc1'
         chunks = {
-            0: {'chunk_header': 'Header 1', 'chunk_text': 'Content of chunk 1'}
+            0: {'chunk_text': 'Content of chunk 1'}
         }
         db.add_document(doc_id, chunks)
         db.remove_document(doc_id)
@@ -61,7 +91,7 @@ class TestChunkDB(unittest.TestCase):
         db = BasicChunkDB(self.kb_id, self.storage_directory)
         doc_id = 'doc1'
         chunks = {
-            0: {'chunk_header': 'Header 1', 'chunk_text': 'Content of chunk 1'}
+            0: {'chunk_text': 'Content of chunk 1', 'document_title': 'Title of document 1', 'document_summary': 'Summary of document 1', 'section_title': 'Section title 1', 'section_summary': 'Section summary 1'},
         }
         db.add_document(doc_id, chunks)
         db2 = BasicChunkDB(self.kb_id, self.storage_directory)
@@ -78,7 +108,7 @@ class TestChunkDB(unittest.TestCase):
         db = BasicChunkDB(self.kb_id, self.storage_directory)
         doc_id = 'doc1'
         chunks = {
-            0: {'chunk_header': 'Header 1', 'chunk_text': 'Content of chunk 1'}
+            0: {'chunk_text': 'Content of chunk 1'}
         }
         db.add_document(doc_id, chunks)
         # Make sure the storage directory exists before deleting it


### PR DESCRIPTION
AutoContext originally just referred to the process of creating a document summary to include in a chunk header. With the addition of semantic sectioning (which produces section titles), this needed to be refactored so that AutoContext refers to the complete chunk header creation process.

We now have four pieces of information that can be included in the chunk header:
- `document_title` - can be provided as input or can be generated via LLM
- `document_summary`
- `section_title` - generated by LLM in the semantic sectioning process
- `section_summary` - generated by LLM (only possible if semantic sectioning is used)