### PR TITLE
Sqlite chunk db

### DIFF
--- a/dsrag/chunk_db.py
+++ b/dsrag/chunk_db.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 import os
 import pickle
+import sqlite3
 
 class ChunkDB(ABC):
     subclasses = {}
@@ -164,4 +165,132 @@ class BasicChunkDB(ChunkDB):
             **super().to_dict(),
             'kb_id': self.kb_id,
             'storage_directory': self.storage_directory,
+        }
+    
+
+class SQLiteDB(ChunkDB):
+
+    def __init__(self, kb_id: str, title: str = "", description: str = "", language: str = "en", db_path: str = '~/dsRAG'):
+        self.kb_id = kb_id
+        self.storage_directory = os.path.expanduser(db_path)
+        os.makedirs(os.path.join(self.storage_directory, 'chunk_storage'), exist_ok=True)
+        self.db_path = os.path.join(self.storage_directory, 'chunk_storage')
+
+        # Make sure main knowledge bases table exists
+        conn = sqlite3.connect(os.path.join(self.db_path, 'dsRAG.db'))
+        c = conn.cursor()
+        result = c.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='knowledge_bases'")
+        if not result.fetchone():
+            c.execute("CREATE TABLE knowledge_bases (kb_id VARCHAR(256) PRIMARY KEY, title VARCHAR(256), description TEXT, language VARCHAR(16))")
+            conn.commit()
+        conn.close()
+
+        # Create a table for this kb_id if it doesn't exist
+        conn = sqlite3.connect(os.path.join(self.db_path, 'dsRAG.db'))
+        c = conn.cursor()
+        result = c.execute(f"SELECT name FROM sqlite_master WHERE type='table' AND name='{kb_id}'")
+        if not result.fetchone():
+            # Insert this kb into the table
+            c.execute("INSERT INTO knowledge_bases (kb_id, title, description, language) VALUES (?, ?, ?, ?)", (kb_id, title, description, language))
+            c.execute(f"CREATE TABLE {kb_id} (doc_id VARCHAR(256), document_title VARCHAR(256), document_summary TEXT, section_title VARCHAR(256), section_summary TEXT, chunk_text TEXT, chunk_index INT)")
+            conn.commit()
+        conn.close()
+        
+
+    def add_document(self, doc_id: str, chunks: dict[dict]):
+        # Add the docs to the sqlite table
+        conn = sqlite3.connect(os.path.join(self.db_path, 'dsRAG.db'))
+        c = conn.cursor()
+        # Get the data from the dictionary
+        for chunk_index, chunk in chunks.items():
+            document_title = chunk.get('document_title', "")
+            document_summary = chunk.get('document_summary', "")
+            section_title = chunk.get('section_title', "")
+            section_summary = chunk.get('section_summary', "")
+            chunk_text = chunk.get('chunk_text', "")
+            c.execute(f"INSERT INTO {self.kb_id} (doc_id, document_title, document_summary, section_title, section_summary, chunk_text, chunk_index) VALUES (?, ?, ?, ?, ?, ?, ?)", (doc_id, document_title, document_summary, section_title, section_summary, chunk_text, chunk_index))
+
+        conn.commit()
+        conn.close()
+
+    def remove_document(self, doc_id: str):
+        # Remove the docs from the sqlite table
+        conn = sqlite3.connect(os.path.join(self.db_path, 'dsRAG.db'))
+        c = conn.cursor()
+        c.execute(f"DELETE FROM {self.kb_id} WHERE doc_id='{doc_id}'")
+        conn.commit()
+        conn.close()
+
+    def get_chunk_text(self, doc_id: str, chunk_index: int) -> str:
+        # Retrieve the chunk text from the sqlite table
+        conn = sqlite3.connect(os.path.join(self.db_path, 'dsRAG.db'))
+        c = conn.cursor()
+        c.execute(f"SELECT chunk_text FROM {self.kb_id} WHERE doc_id='{doc_id}' AND chunk_index={chunk_index}")
+        result = c.fetchone()
+        conn.close()
+        if result:
+            return result[0]
+        return ""
+
+    def get_document_title(self, doc_id: str, chunk_index: int) -> str:
+        # Retrieve the document title from the sqlite table
+        conn = sqlite3.connect(os.path.join(self.db_path, 'dsRAG.db'))
+        c = conn.cursor()
+        c.execute(f"SELECT document_title FROM {self.kb_id} WHERE doc_id='{doc_id}' AND chunk_index={chunk_index}")
+        result = c.fetchone()
+        conn.close()
+        if result:
+            return result[0]
+        return ""
+
+    def get_document_summary(self, doc_id: str, chunk_index: int) -> str:
+        # Retrieve the document summary from the sqlite table
+        conn = sqlite3.connect(os.path.join(self.db_path, 'dsRAG.db'))
+        c = conn.cursor()
+        c.execute(f"SELECT document_summary FROM {self.kb_id} WHERE doc_id='{doc_id}' AND chunk_index={chunk_index}")
+        result = c.fetchone()
+        conn.close()
+        if result:
+            return result[0]
+        return ""
+
+    def get_section_title(self, doc_id: str, chunk_index: int) -> str:
+        # Retrieve the section title from the sqlite table
+        conn = sqlite3.connect(os.path.join(self.db_path, 'dsRAG.db'))
+        c = conn.cursor()
+        c.execute(f"SELECT section_title FROM {self.kb_id} WHERE doc_id='{doc_id}' AND chunk_index={chunk_index}")
+        result = c.fetchone()
+        conn.close()
+        if result:
+            return result[0]
+        return ""
+
+    def get_section_summary(self, doc_id: str, chunk_index: int) -> str:
+        # Retrieve the section summary from the sqlite table
+        conn = sqlite3.connect(os.path.join(self.db_path, 'dsRAG.db'))
+        c = conn.cursor()
+        c.execute(f"SELECT section_summary FROM {self.kb_id} WHERE doc_id='{doc_id}' AND chunk_index={chunk_index}")
+        result = c.fetchone()
+        conn.close()
+        if result:
+            return result[0]
+        return ""
+
+    def get_all_doc_ids(self) -> list:
+        # Retrieve all document IDs from the sqlite table
+        conn = sqlite3.connect(os.path.join(self.db_path, 'dsRAG.db'))
+        c = conn.cursor()
+        c.execute(f"SELECT DISTINCT doc_id FROM {self.kb_id}")
+        results = c.fetchall()
+        conn.close()
+        return [result[0] for result in results]
+
+    def to_dict(self):
+        return {
+            **super().to_dict(),
+            'kb_id': self.kb_id,
+            'db_path': self.db_path,
+            'title': self.title,
+            'description': self.description,
+            'language': self.language,
         }

--- a/dsrag/chunk_db.py
+++ b/dsrag/chunk_db.py
@@ -253,6 +253,10 @@ class SQLiteDB(ChunkDB):
         results = c.fetchall()
         conn.close()
 
+        # If there are no results, return an empty dictionary
+        if not results:
+            return None
+
         formatted_results = {}
         # Turn the results into an object where the columns are keys
         if include_content:

--- a/dsrag/chunk_db.py
+++ b/dsrag/chunk_db.py
@@ -46,6 +46,13 @@ class ChunkDB(ABC):
         pass
 
     @abstractmethod
+    def get_document(self, doc_id: str) -> dict:
+        """
+        Retrieve all chunks from a given document ID.
+        """
+        pass
+
+    @abstractmethod
     def get_document_title(self, doc_id: str, chunk_index: int) -> str:
         """
         Retrieve the document title of a specific chunk from a given document ID.
@@ -109,6 +116,28 @@ class BasicChunkDB(ChunkDB):
         if doc_id in self.data and chunk_index in self.data[doc_id]:
             return self.data[doc_id][chunk_index]['chunk_text']
         return None
+    
+    def get_document(self, doc_id: str, include_content: bool = False) -> dict:
+        if doc_id in self.data:
+            document = self.data[doc_id]
+            formatted_document = {
+                'doc_id': doc_id,
+                'document_title': document[0].get('document_title', "")
+            }
+            
+            if include_content:
+                # Concatenate the chunks into a single string
+                full_document_string = ""
+                for chunk_index, chunk in document.items():
+                    # Join each chunk text with a new line character
+                    full_document_string += chunk['chunk_text'] + "\n"
+                formatted_document["content"] = full_document_string
+            
+            return formatted_document
+        
+        else:
+            return None
+
 
     def get_document_title(self, doc_id: str, chunk_index: int) -> str:
         if doc_id in self.data and chunk_index in self.data[doc_id]:
@@ -170,36 +199,26 @@ class BasicChunkDB(ChunkDB):
 
 class SQLiteDB(ChunkDB):
 
-    def __init__(self, kb_id: str, title: str = "", description: str = "", language: str = "en", db_path: str = '~/dsRAG'):
+    def __init__(self, kb_id: str, storage_directory: str = '~/dsRAG'):
         self.kb_id = kb_id
-        self.storage_directory = os.path.expanduser(db_path)
+        self.storage_directory = os.path.expanduser(storage_directory)
         os.makedirs(os.path.join(self.storage_directory, 'chunk_storage'), exist_ok=True)
         self.db_path = os.path.join(self.storage_directory, 'chunk_storage')
 
-        # Make sure main knowledge bases table exists
-        conn = sqlite3.connect(os.path.join(self.db_path, 'dsRAG.db'))
-        c = conn.cursor()
-        result = c.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='knowledge_bases'")
-        if not result.fetchone():
-            c.execute("CREATE TABLE knowledge_bases (kb_id VARCHAR(256) PRIMARY KEY, title VARCHAR(256), description TEXT, language VARCHAR(16))")
-            conn.commit()
-        conn.close()
-
         # Create a table for this kb_id if it doesn't exist
-        conn = sqlite3.connect(os.path.join(self.db_path, 'dsRAG.db'))
+        conn = sqlite3.connect(os.path.join(self.db_path, f'{kb_id}.db'))
         c = conn.cursor()
-        result = c.execute(f"SELECT name FROM sqlite_master WHERE type='table' AND name='{kb_id}'")
+        result = c.execute(f"SELECT name FROM sqlite_master WHERE type='table' AND name='documents'")
         if not result.fetchone():
-            # Insert this kb into the table
-            c.execute("INSERT INTO knowledge_bases (kb_id, title, description, language) VALUES (?, ?, ?, ?)", (kb_id, title, description, language))
-            c.execute(f"CREATE TABLE {kb_id} (doc_id VARCHAR(256), document_title VARCHAR(256), document_summary TEXT, section_title VARCHAR(256), section_summary TEXT, chunk_text TEXT, chunk_index INT)")
+            # Create a table for this kb_id
+            c.execute(f"CREATE TABLE documents (doc_id VARCHAR(256), document_title VARCHAR(256), document_summary TEXT, section_title VARCHAR(256), section_summary TEXT, chunk_text TEXT, chunk_index INT)")
             conn.commit()
         conn.close()
         
 
     def add_document(self, doc_id: str, chunks: dict[dict]):
         # Add the docs to the sqlite table
-        conn = sqlite3.connect(os.path.join(self.db_path, 'dsRAG.db'))
+        conn = sqlite3.connect(os.path.join(self.db_path, f'{self.kb_id}.db'))
         c = conn.cursor()
         # Get the data from the dictionary
         for chunk_index, chunk in chunks.items():
@@ -208,24 +227,52 @@ class SQLiteDB(ChunkDB):
             section_title = chunk.get('section_title', "")
             section_summary = chunk.get('section_summary', "")
             chunk_text = chunk.get('chunk_text', "")
-            c.execute(f"INSERT INTO {self.kb_id} (doc_id, document_title, document_summary, section_title, section_summary, chunk_text, chunk_index) VALUES (?, ?, ?, ?, ?, ?, ?)", (doc_id, document_title, document_summary, section_title, section_summary, chunk_text, chunk_index))
+            c.execute(f"INSERT INTO documents (doc_id, document_title, document_summary, section_title, section_summary, chunk_text, chunk_index) VALUES (?, ?, ?, ?, ?, ?, ?)", (doc_id, document_title, document_summary, section_title, section_summary, chunk_text, chunk_index))
 
         conn.commit()
         conn.close()
 
     def remove_document(self, doc_id: str):
         # Remove the docs from the sqlite table
-        conn = sqlite3.connect(os.path.join(self.db_path, 'dsRAG.db'))
+        conn = sqlite3.connect(os.path.join(self.db_path, f'{self.kb_id}.db'))
         c = conn.cursor()
-        c.execute(f"DELETE FROM {self.kb_id} WHERE doc_id='{doc_id}'")
+        c.execute(f"DELETE FROM documents WHERE doc_id='{doc_id}'")
         conn.commit()
         conn.close()
+    
+    def get_document(self, doc_id: str, include_content: bool = False) -> dict:
+        # Retrieve the document from the sqlite table
+        conn = sqlite3.connect(os.path.join(self.db_path, f'{self.kb_id}.db'))
+        c = conn.cursor()
+        columns = ["doc_id", "document_title", "document_summary"]
+        if include_content:
+            columns += ["section_title", "section_summary", "chunk_text", "chunk_index"]
+
+        query_statement = f"SELECT {', '.join(columns)} FROM documents WHERE doc_id='{doc_id}'"
+        c.execute(query_statement)
+        results = c.fetchall()
+        conn.close()
+
+        formatted_results = {}
+        # Turn the results into an object where the columns are keys
+        if include_content:
+            # Concatenate the chunks into a single string
+            full_document_string = ""
+            for result in results:
+                # Join each chunk text with a new line character
+                full_document_string += result[5] + "\n"
+            formatted_results["content"] = full_document_string
+
+        formatted_results["doc_id"] = doc_id
+        formatted_results["document_title"] = results[0][1]
+
+        return formatted_results
 
     def get_chunk_text(self, doc_id: str, chunk_index: int) -> str:
         # Retrieve the chunk text from the sqlite table
-        conn = sqlite3.connect(os.path.join(self.db_path, 'dsRAG.db'))
+        conn = sqlite3.connect(os.path.join(self.db_path, f'{self.kb_id}.db'))
         c = conn.cursor()
-        c.execute(f"SELECT chunk_text FROM {self.kb_id} WHERE doc_id='{doc_id}' AND chunk_index={chunk_index}")
+        c.execute(f"SELECT chunk_text FROM documents WHERE doc_id='{doc_id}' AND chunk_index={chunk_index}")
         result = c.fetchone()
         conn.close()
         if result:
@@ -234,9 +281,9 @@ class SQLiteDB(ChunkDB):
 
     def get_document_title(self, doc_id: str, chunk_index: int) -> str:
         # Retrieve the document title from the sqlite table
-        conn = sqlite3.connect(os.path.join(self.db_path, 'dsRAG.db'))
+        conn = sqlite3.connect(os.path.join(self.db_path, f'{self.kb_id}.db'))
         c = conn.cursor()
-        c.execute(f"SELECT document_title FROM {self.kb_id} WHERE doc_id='{doc_id}' AND chunk_index={chunk_index}")
+        c.execute(f"SELECT document_title FROM documents WHERE doc_id='{doc_id}' AND chunk_index={chunk_index}")
         result = c.fetchone()
         conn.close()
         if result:
@@ -245,9 +292,9 @@ class SQLiteDB(ChunkDB):
 
     def get_document_summary(self, doc_id: str, chunk_index: int) -> str:
         # Retrieve the document summary from the sqlite table
-        conn = sqlite3.connect(os.path.join(self.db_path, 'dsRAG.db'))
+        conn = sqlite3.connect(os.path.join(self.db_path, f'{self.kb_id}.db'))
         c = conn.cursor()
-        c.execute(f"SELECT document_summary FROM {self.kb_id} WHERE doc_id='{doc_id}' AND chunk_index={chunk_index}")
+        c.execute(f"SELECT document_summary FROM documents WHERE doc_id='{doc_id}' AND chunk_index={chunk_index}")
         result = c.fetchone()
         conn.close()
         if result:
@@ -256,9 +303,9 @@ class SQLiteDB(ChunkDB):
 
     def get_section_title(self, doc_id: str, chunk_index: int) -> str:
         # Retrieve the section title from the sqlite table
-        conn = sqlite3.connect(os.path.join(self.db_path, 'dsRAG.db'))
+        conn = sqlite3.connect(os.path.join(self.db_path, f'{self.kb_id}.db'))
         c = conn.cursor()
-        c.execute(f"SELECT section_title FROM {self.kb_id} WHERE doc_id='{doc_id}' AND chunk_index={chunk_index}")
+        c.execute(f"SELECT section_title FROM documents WHERE doc_id='{doc_id}' AND chunk_index={chunk_index}")
         result = c.fetchone()
         conn.close()
         if result:
@@ -267,9 +314,9 @@ class SQLiteDB(ChunkDB):
 
     def get_section_summary(self, doc_id: str, chunk_index: int) -> str:
         # Retrieve the section summary from the sqlite table
-        conn = sqlite3.connect(os.path.join(self.db_path, 'dsRAG.db'))
+        conn = sqlite3.connect(os.path.join(self.db_path, f'{self.kb_id}.db'))
         c = conn.cursor()
-        c.execute(f"SELECT section_summary FROM {self.kb_id} WHERE doc_id='{doc_id}' AND chunk_index={chunk_index}")
+        c.execute(f"SELECT section_summary FROM documents WHERE doc_id='{doc_id}' AND chunk_index={chunk_index}")
         result = c.fetchone()
         conn.close()
         if result:
@@ -278,19 +325,21 @@ class SQLiteDB(ChunkDB):
 
     def get_all_doc_ids(self) -> list:
         # Retrieve all document IDs from the sqlite table
-        conn = sqlite3.connect(os.path.join(self.db_path, 'dsRAG.db'))
+        conn = sqlite3.connect(os.path.join(self.db_path, f'{self.kb_id}.db'))
         c = conn.cursor()
-        c.execute(f"SELECT DISTINCT doc_id FROM {self.kb_id}")
+        c.execute(f"SELECT DISTINCT doc_id FROM documents")
         results = c.fetchall()
         conn.close()
         return [result[0] for result in results]
+
+    def delete(self):
+        # Delete the sqlite database
+        if os.path.exists(os.path.join(self.db_path, f'{self.kb_id}.db')):
+            os.remove(os.path.join(self.db_path, f'{self.kb_id}.db'))
 
     def to_dict(self):
         return {
             **super().to_dict(),
             'kb_id': self.kb_id,
-            'db_path': self.db_path,
-            'title': self.title,
-            'description': self.description,
-            'language': self.language,
+            'storage_directory': self.storage_directory
         }

--- a/tests/unit/test_chunk_db.py
+++ b/tests/unit/test_chunk_db.py
@@ -4,7 +4,7 @@ import unittest
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
 
-from dsrag.chunk_db import BasicChunkDB, ChunkDB
+from dsrag.chunk_db import BasicChunkDB, ChunkDB, SQLiteDB
 import shutil
 
 
@@ -117,6 +117,121 @@ class TestChunkDB(unittest.TestCase):
         # Make sure the storage directory does not exist
         self.assertFalse(os.path.exists(db.storage_path))
         
+
+class TestSQLiteDB(unittest.TestCase):
+
+    def setUp(self):
+        self.storage_directory = '~/test__sqlite_db_dsRAG'
+        self.kb_id = 'test_kb'
+        resolved_test_storage_directory = os.path.expanduser(self.storage_directory)
+        if os.path.exists(resolved_test_storage_directory):
+            shutil.rmtree(resolved_test_storage_directory)
+        return super().setUp()
+    
+    @classmethod
+    def tearDownClass(cls):
+        test_storage_directory = '~/test__chunk_db_dsRAG'
+        resolved_test_storage_directory = os.path.expanduser(test_storage_directory)
+        if os.path.exists(resolved_test_storage_directory):
+            shutil.rmtree(resolved_test_storage_directory)
+        return super().tearDownClass()
+    
+    def test__add_and_get_chunk_text(self):
+        db = SQLiteDB(self.kb_id, self.storage_directory)
+        doc_id = 'doc1'
+        chunks = {
+            0: {'chunk_text': 'Content of chunk 1', 'document_title': 'Title of document 1', 'document_summary': 'Summary of document 1', 'section_title': 'Section title 1', 'section_summary': 'Section summary 1'},
+            1: {'chunk_text': 'Content of chunk 2', 'document_title': 'Title of document 2', 'document_summary': 'Summary of document 2', 'section_title': 'Section title 2', 'section_summary': 'Section summary 2'},
+        }
+        db.add_document(doc_id, chunks)
+        retrieved_chunk = db.get_chunk_text(doc_id, 0)
+        self.assertEqual(retrieved_chunk, chunks[0]['chunk_text'])
+
+    def test__get_document_title(self):
+        db = SQLiteDB(self.kb_id, self.storage_directory)
+        doc_id = 'doc1'
+        chunks = {
+            0: {'document_title': 'Title 1', 'chunk_text': 'Content of chunk 1'}
+        }
+        db.add_document(doc_id, chunks)
+        title = db.get_document_title(doc_id, 0)
+        self.assertEqual(title, 'Title 1')
+
+    def test__get_document_summary(self):
+        db = SQLiteDB(self.kb_id, self.storage_directory)
+        doc_id = 'doc1'
+        chunks = {
+            0: {'document_summary': 'Summary 1', 'chunk_text': 'Content of chunk 1'}
+        }
+        db.add_document(doc_id, chunks)
+        summary = db.get_document_summary(doc_id, 0)
+        self.assertEqual(summary, 'Summary 1')
+
+    def test__get_section_title(self):
+        db = SQLiteDB(self.kb_id, self.storage_directory)
+        doc_id = 'doc1'
+        chunks = {
+            0: {'section_title': 'Title 1', 'chunk_text': 'Content of chunk 1'}
+        }
+        db.add_document(doc_id, chunks)
+        title = db.get_section_title(doc_id, 0)
+        self.assertEqual(title, 'Title 1')
+    
+    def test__get_section_summary(self):
+        db = SQLiteDB(self.kb_id, self.storage_directory)
+        doc_id = 'doc1'
+        chunks = {
+            0: {'section_summary': 'Summary 1', 'chunk_text': 'Content of chunk 1'}
+        }
+        db.add_document(doc_id, chunks)
+        summary = db.get_section_summary(doc_id, 0)
+        self.assertEqual(summary, 'Summary 1')
+
+    def test__remove_document(self):
+        db = SQLiteDB(self.kb_id, self.storage_directory)
+        doc_id = 'doc1'
+        chunks = {
+            0: {'chunk_text': 'Content of chunk 1'}
+        }
+        db.add_document(doc_id, chunks)
+        db.remove_document(doc_id)
+        results = db.get_document(doc_id)
+        print ("results", results)
+        # Make sure the document does not exist, it should just be None
+        self.assertIsNone(results)
+
+    """def test__persistence(self):
+        db = SQLiteDB(self.kb_id, self.storage_directory)
+        doc_id = 'doc1'
+        chunks = {
+            0: {'chunk_text': 'Content of chunk 1', 'document_title': 'Title of document 1', 'document_summary': 'Summary of document 1', 'section_title': 'Section title 1', 'section_summary': 'Section summary 1'},
+        }
+        db.add_document(doc_id, chunks)
+        db2 = SQLiteDB(self.kb_id, self.storage_directory)
+        self.assertIn(doc_id, db2.data)"""
+
+    def test__save_and_load_from_dict(self):
+        db = SQLiteDB(self.kb_id, self.storage_directory)
+        config = db.to_dict()
+        db2 = ChunkDB.from_dict(config)
+        assert db2.kb_id == db.kb_id, "Failed to load kb_id from dict."
+        self.assertEqual(db2.kb_id, db.kb_id)
+    
+    def test__delete(self):
+        db = SQLiteDB(self.kb_id, self.storage_directory)
+        doc_id = 'doc1'
+        chunks = {
+            0: {'chunk_text': 'Content of chunk 1'}
+        }
+        db.add_document(doc_id, chunks)
+        # Make sure the storage directory exists before deleting it
+        print ("db.db_path", os.path.join(db.db_path, f'{self.kb_id}.db'))
+        self.assertTrue(os.path.exists(os.path.join(db.db_path, f'{self.kb_id}.db')))
+        db.delete()
+        # Make sure the storage directory does not exist
+        self.assertFalse(os.path.exists(os.path.join(db.db_path, f'{self.kb_id}.db')))
+
+
 
 # Run all tests
 if __name__ == '__main__':

--- a/tests/unit/test_chunk_db.py
+++ b/tests/unit/test_chunk_db.py
@@ -200,16 +200,6 @@ class TestSQLiteDB(unittest.TestCase):
         # Make sure the document does not exist, it should just be None
         self.assertIsNone(results)
 
-    """def test__persistence(self):
-        db = SQLiteDB(self.kb_id, self.storage_directory)
-        doc_id = 'doc1'
-        chunks = {
-            0: {'chunk_text': 'Content of chunk 1', 'document_title': 'Title of document 1', 'document_summary': 'Summary of document 1', 'section_title': 'Section title 1', 'section_summary': 'Section summary 1'},
-        }
-        db.add_document(doc_id, chunks)
-        db2 = SQLiteDB(self.kb_id, self.storage_directory)
-        self.assertIn(doc_id, db2.data)"""
-
     def test__save_and_load_from_dict(self):
         db = SQLiteDB(self.kb_id, self.storage_directory)
         config = db.to_dict()


### PR DESCRIPTION
Added support for a SQLite table as the chunk db.
Also added a new `get_document` function for the BasicChunkDB class that returns an entire document when no `chunk_index` is provided