### PR TITLE
Emcl/sql alchemy dbs

### DIFF
--- a/dsrag/database/chunk/__init__.py
+++ b/dsrag/database/chunk/__init__.py
@@ -2,3 +2,4 @@ from .basic_db import BasicChunkDB
 from .sqlite_db import SQLiteDB
 from .db import ChunkDB
 from .types import FormattedDocument
+from .sql_alchemy_db import PostgresChunkDB

--- a/dsrag/database/chunk/sql_alchemy_db.py
+++ b/dsrag/database/chunk/sql_alchemy_db.py
@@ -1,0 +1,141 @@
+from typing import Any
+from dsrag.database.chunk.db import ChunkDB
+from dsrag.database.vector.types import TranscriptChunk
+
+
+class PostgresChunkDB(ChunkDB):
+    def __init__(self, db: Session, kb_id: str):
+        self.kb_id = kb_id
+        self.db = db
+
+    def add_document(self, doc_id: str, chunks: dict[str, dict[str, Any]]) -> None:
+        for chunk_index, chunk in chunks.items():
+            document_title = chunk.get("document_title", "")
+            document_summary = chunk.get("document_summary", "")
+            section_title = chunk.get("section_title", "")
+            section_summary = chunk.get("section_summary", "")
+            chunk_text = chunk.get("chunk_text", "")
+            document = TranscriptChunk(
+                doc_id=doc_id,
+                document_title=document_title,
+                document_summary=document_summary,
+                section_title=section_title,
+                section_summary=section_summary,
+                chunk_text=chunk_text,
+                chunk_index=chunk_index,
+            )
+            self.db.add(document)
+        self.db.commit()
+
+    def remove_document(self, doc_id: str) -> None:
+        self.db.query(TranscriptChunk).filter(TranscriptChunk.doc_id == doc_id).delete()
+        self.db.commit()
+
+    def get_document(self, doc_id: str, include_content: bool = False) -> dict:
+        columns = [
+            TranscriptChunk.doc_id,
+            TranscriptChunk.document_title,
+            TranscriptChunk.document_summary,
+        ]
+        if include_content:
+            columns += [
+                TranscriptChunk.section_title,
+                TranscriptChunk.section_summary,
+                TranscriptChunk.chunk_text,
+                TranscriptChunk.chunk_index,
+            ]
+
+        results = (
+            self.db.query(TranscriptChunk)
+            .filter(TranscriptChunk.doc_id == doc_id)
+            .all()
+        )
+
+        if not results:
+            return {}
+
+        formatted_results = {}
+        if include_content:
+            full_document_string = "\n".join([result.chunk_text for result in results])
+            formatted_results["content"] = full_document_string
+
+        formatted_results["doc_id"] = doc_id
+        formatted_results["document_title"] = results[0].document_title
+
+        return formatted_results
+
+    def get_chunk_text(self, doc_id: str, chunk_index: int) -> str:
+        chunk_text = (
+            self.db.query(TranscriptChunk.chunk_text)
+            .filter(
+                TranscriptChunk.doc_id == doc_id,
+                TranscriptChunk.chunk_index == chunk_index,
+            )
+            .one()
+        )
+        if chunk_text:
+            return chunk_text[0]
+        return ""
+
+    def get_document_title(self, doc_id: str, chunk_index: int) -> str:
+        result = (
+            self.db.query(TranscriptChunk.document_title)
+            .filter(
+                TranscriptChunk.doc_id == doc_id,
+                TranscriptChunk.chunk_index == chunk_index,
+            )
+            .one()
+        )
+        if result:
+            return result[0]
+        return ""
+
+    def get_document_summary(self, doc_id: str, chunk_index: int) -> str:
+        document_summary = (
+            self.db.query(TranscriptChunk.document_summary)
+            .filter(
+                TranscriptChunk.doc_id == doc_id,
+                TranscriptChunk.chunk_index == chunk_index,
+            )
+            .one()
+        )
+        if document_summary:
+            return document_summary[0]
+        return ""
+
+    def get_section_title(self, doc_id: str, chunk_index: int) -> str:
+        section_title = (
+            self.db.query(TranscriptChunk.section_title)
+            .filter(
+                TranscriptChunk.doc_id == doc_id,
+                TranscriptChunk.chunk_index == chunk_index,
+            )
+            .one()
+        )
+        if section_title:
+            return section_title[0]
+        return ""
+
+    def get_section_summary(self, doc_id: str, chunk_index: int) -> str:
+        section_summary = (
+            self.db.query(TranscriptChunk.section_summary)
+            .filter(
+                TranscriptChunk.doc_id == doc_id,
+                TranscriptChunk.chunk_index == chunk_index,
+            )
+            .one()
+        )
+        if section_summary:
+            return section_summary[0]
+        return ""
+
+    def get_all_doc_ids(self, supp_id: str | None = None) -> list:  # noqa: ARG002
+        results = self.db.query(TranscriptChunk.doc_id).distinct().all()
+        return [result.doc_id for result in results]
+
+    def delete(self) -> None: ...
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            **super().to_dict(),
+        }

--- a/dsrag/database/vector/__init__.py
+++ b/dsrag/database/vector/__init__.py
@@ -3,3 +3,4 @@ from .basic_db import BasicVectorDB
 from .chroma_db import ChromaDB
 from .types import VectorSearchResult, Vector, ChunkMetadata
 from .weaviate_db import WeaviateVectorDB
+from .sql_alchemy_db import PostgresVectorDB

--- a/dsrag/database/vector/chroma_db.py
+++ b/dsrag/database/vector/chroma_db.py
@@ -48,7 +48,6 @@ class ChromaDB(VectorDB):
         )
 
         metadata = query_results["metadatas"][0]
-        metadata = query_results["metadatas"][0]
         distances = query_results["distances"][0]
 
         results: list[VectorSearchResult] = []

--- a/dsrag/database/vector/sql_alchemy_db.py
+++ b/dsrag/database/vector/sql_alchemy_db.py
@@ -1,0 +1,139 @@
+from typing import Any, Sequence
+from dsrag.database.vector.types import (
+    ChunkEmbedding,
+    ChunkMetadata,
+    Vector,
+    VectorSearchResult,
+)
+from .db import VectorDB
+
+
+class PostgresVectorDB(VectorDB):
+    """
+    An implementation of the VectorDB interface for Postgres.
+
+    This class provides methods for adding, removing, and searching for vectorized data
+    within a Postgres instance.
+    """
+
+    def __init__(
+        self,
+        # Needs to be imported from SQLAlchemy
+        db: Session,
+        kb_id: str,
+        init_timeout: int = 2,
+        query_timeout: int = 45,
+        insert_timeout: int = 120,
+    ):
+        self.kb_id = kb_id
+        self.init_timeout = init_timeout
+        self.query_timeout = query_timeout
+        self.insert_timeout = insert_timeout
+        self.db = db
+
+    def add_vectors(
+        self, vectors: Sequence[Vector], metadata: Sequence[ChunkMetadata]
+    ) -> None:
+        """
+        Adds a list of vectors with associated metadata to Postgres Vector DB.
+
+        Args:
+            vectors: A list of vector embeddings.
+            metadata: A list of dictionaries containing metadata for each vector.
+
+        Raises:
+            ValueError: If the number of vectors and metadata items do not match.
+        """
+        if len(vectors) != len(metadata):
+            raise ValueError("The number of vectors and metadata items must match.")
+
+        for vector, meta in zip(vectors, metadata, strict=False):
+            doc_id = meta.get("doc_id", "")
+            if not doc_id:
+                raise ValueError("Metadata must contain a 'doc_id' key.")
+
+            embedding = ChunkEmbedding(
+                kb_id=self.kb_id,
+                transcript_id=doc_id,
+                vector=vector,
+                chunk_metadata=meta,
+            )
+            self.db.add(embedding)
+        self.db.commit()
+
+    def remove_document(self, doc_id: str):
+        """
+        Removes a document (data object) from Postgres Vector DB.
+
+        Args:
+            doc_id: The UUID of the document to remove.
+        """
+        self.db.query(ChunkEmbedding).filter(
+            ChunkEmbedding.chunk_metadata["doc_id"] == doc_id,
+            ChunkEmbedding.kb_id == self.kb_id,
+        ).delete()
+        self.db.commit()
+
+    def search(self, query_vector: Vector, top_k: int = 10) -> list[VectorSearchResult]:
+        """
+        Searches for the top-k closest vectors to the given query vector.
+
+        Args:
+            query_vector: The query vector embedding.
+            top_k: The number of results to return.
+
+        Returns:
+            A list of dictionaries containing the metadata and similarity scores of
+            the top-k results.
+        """
+        min_score = 0.26
+        matching_embeddings = (
+            self.db.query(
+                ChunkEmbedding,
+                ChunkEmbedding.vector.max_inner_product(query_vector),
+            )
+            .filter(
+                # and_ needs to be imported from SQLALchemy
+                and_(
+                    ChunkEmbedding.kb_id == self.kb_id,
+                    ChunkEmbedding.vector.max_inner_product(query_vector)
+                    <= -1 * min_score,
+                )
+            )
+            .order_by(ChunkEmbedding.vector.max_inner_product(query_vector).asc())
+            .all()
+        )
+
+        top_k_matching_embeddings = (
+            matching_embeddings[:top_k] if top_k > 0 else matching_embeddings
+        )
+
+        search_results: list[VectorSearchResult] = []
+        for mp in top_k_matching_embeddings:
+            result: VectorSearchResult = VectorSearchResult(
+                doc_id=mp[0].transcript_id,
+                vector=None,
+                metadata=mp[0].chunk_metadata,
+                similarity=mp[1],
+            )
+            search_results.append(result)
+        return search_results
+
+    def delete(self) -> None:
+        """
+        Deletes the vector database.
+        """
+        self.db.query(ChunkEmbedding).filter(
+            ChunkEmbedding.kb_id == self.kb_id
+        ).delete()
+        self.db.commit()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            **super().to_dict(),
+            "subclass_name": self.__class__.__name__,
+            "kb_id": self.kb_id,
+            "init_timeout": self.init_timeout,
+            "query_timeout": self.query_timeout,
+            "insert_timeout": self.insert_timeout,
+        }

--- a/dsrag/database/vector/types.py
+++ b/dsrag/database/vector/types.py
@@ -21,3 +21,39 @@ class VectorSearchResult(TypedDict):
     vector: Vector | None
     metadata: ChunkMetadata
     similarity: float
+
+
+# declarative_base, Column, String, Integer, func, deferred, Vector need to be imported from SQLAlchemy
+Base = declarative_base()
+
+
+class ChunkMetadata(TypedDict):
+    doc_id: str
+    chunk_text: str
+    chunk_index: int
+    chunk_header: str
+    document_title: str
+    document_summary: str
+    section_title: str
+    section_summary: str
+
+
+class ChunkEmbedding(Base):
+    __tablename__ = "chunk_embedding"
+
+    id = Column(UUID, primary_key=True, server_default=func.uuid_generate_v1mc())
+    kb_id = Column(String, nullable=False)
+    transcript_id = Column(String, nullable=False)
+    vector = deferred(Column(Vector(768), nullable=False))
+    chunk_metadata: ChunkMetadata = Column(MUTABLE_JSONB, nullable=False)  # type: ignore
+
+
+class TranscriptChunk(Base):
+    __tablename__ = "transcript_chunk"
+    doc_id = Column(String, primary_key=True)
+    document_title = Column(String)
+    document_summary = Column(String)
+    section_title = Column(String)
+    section_summary = Column(String)
+    chunk_text = Column(String)
+    chunk_index = Column(Integer, primary_key=True)

--- a/dsrag/database/vector/types.py
+++ b/dsrag/database/vector/types.py
@@ -23,7 +23,7 @@ class VectorSearchResult(TypedDict):
     similarity: float
 
 
-# declarative_base, Column, String, Integer, func, deferred, Vector need to be imported from SQLAlchemy
+# declarative_base, Column, String, Integer, func, deferred need to be imported from SQLAlchemy
 Base = declarative_base()
 
 
@@ -44,6 +44,8 @@ class ChunkEmbedding(Base):
     id = Column(UUID, primary_key=True, server_default=func.uuid_generate_v1mc())
     kb_id = Column(String, nullable=False)
     transcript_id = Column(String, nullable=False)
+    # The vector column we use is from pgvector. Not sure how well this transfers to non-Postgres databases.
+    # https://github.com/pgvector/pgvector-python/blob/master/pgvector/sqlalchemy/vector.py
     vector = deferred(Column(Vector(768), nullable=False))
     chunk_metadata: ChunkMetadata = Column(MUTABLE_JSONB, nullable=False)  # type: ignore
 


### PR DESCRIPTION
Overall Questions:
- Maybe this is not a useful level of abstraction and really what is needed are PostgreSQL DBs. (chunk/postgres_db, vector/postgres_db)
- I am not entirely sure what `supp_id` is and so it is not used in the implementation for SQLAlchemyDB

Some things to look at:

- Imports needed from SQL Alchemy ([I don't think my poetry aligns with yours](https://github.com/D-Star-AI/dsRAG/pull/39#issuecomment-2304003203))
- Making sure Vector works for non-postgres dbs using SQLAlchemy
- Adding tests

