### PR TITLE
Document content bug fix

### DIFF
--- a/dsrag/database/chunk/sqlite_db.py
+++ b/dsrag/database/chunk/sqlite_db.py
@@ -128,7 +128,7 @@ class SQLiteDB(ChunkDB):
             # Concatenate the chunks into a single string
             for result in results:
                 # Join each chunk text with a new line character
-                full_document_string += result[4] + "\n"
+                full_document_string += result[5] + "\n"
 
         supp_id = results[0][0]
         title = results[0][1]

--- a/dsrag/database/chunk/sqlite_db.py
+++ b/dsrag/database/chunk/sqlite_db.py
@@ -128,13 +128,15 @@ class SQLiteDB(ChunkDB):
             # Concatenate the chunks into a single string
             for result in results:
                 # Join each chunk text with a new line character
-                full_document_string += result[5] + "\n"
+                full_document_string += result[columns.index("chunk_text")] + "\n"
+            # Remove the last new line character
+            full_document_string = full_document_string[:-1]
 
-        supp_id = results[0][0]
-        title = results[0][1]
-        summary = results[0][2]
-        created_on = results[0][3]
-        metadata = results[0][4]
+        supp_id = results[0][columns.index("supp_id")]
+        title = results[0][columns.index("document_title")]
+        summary = results[0][columns.index("document_summary")]
+        created_on = results[0][columns.index("created_on")]
+        metadata = results[0][columns.index("metadata")]
 
         # Convert the metadata string back into a dictionary
         if metadata:

--- a/tests/unit/test_chunk_db.py
+++ b/tests/unit/test_chunk_db.py
@@ -188,6 +188,17 @@ class TestSQLiteDB(unittest.TestCase):
         summary = db.get_document_summary(doc_id, 0)
         self.assertEqual(summary, "Summary 1")
 
+    def test__get_document_content(self):
+        db = SQLiteDB(self.kb_id, self.storage_directory)
+        doc_id = "doc1"
+        chunks = {
+            0: {"chunk_text": "Content of chunk 1"},
+            1: {"chunk_text": "Content of chunk 2"},
+        }
+        db.add_document(doc_id, chunks)
+        content = db.get_document(doc_id, include_content=True)
+        self.assertEqual(content["content"], "Content of chunk 1\nContent of chunk 2")
+
     def test__get_section_title(self):
         db = SQLiteDB(self.kb_id, self.storage_directory)
         doc_id = "doc1"


### PR DESCRIPTION
Bug fix to access the correct column when getting the full document content. We are now accessing the column based on the name instead of the expected column number, by using `columns.index({column_name})`. This way if the columns are re-ordered, it will still access the correct index

Also added test for getting the full content