### PR TITLE
PDF page numbers

### DIFF
--- a/dsrag/create_kb.py
+++ b/dsrag/create_kb.py
@@ -28,7 +28,7 @@ def create_kb_from_directory(kb_id: str, directory: str, title: str = None, desc
                     if file_name.endswith('.docx'):
                         text = extract_text_from_docx(file_path)
                     elif file_name.endswith('.pdf'):
-                        text = extract_text_from_pdf(file_path)
+                        text, _ = extract_text_from_pdf(file_path)
                     elif file_name.endswith('.md') or file_name.endswith('.txt'):
                         with open(file_path, 'r') as f:
                             text = f.read()
@@ -69,7 +69,7 @@ def create_kb_from_file(kb_id: str, file_path: str, title: str = None, descripti
         if file_path.endswith('.docx'):
             text = extract_text_from_docx(file_path)
         elif file_name.endswith('.pdf'):
-            text = extract_text_from_pdf(file_path)
+            text, _ = extract_text_from_pdf(file_path)
         elif file_path.endswith('.md') or file_path.endswith('.txt'):
             with open(file_path, 'r') as f:
                 text = f.read()

--- a/dsrag/database/chunk/basic_db.py
+++ b/dsrag/database/chunk/basic_db.py
@@ -41,8 +41,8 @@ class BasicChunkDB(ChunkDB):
     def get_chunk_page_numbers(self, doc_id: str, chunk_index: int) -> Optional[tuple[int, int]]:
         if doc_id in self.data and chunk_index in self.data[doc_id]:
             return (
-                self.data[doc_id][chunk_index].get("chunk_page_start", ""),
-                self.data[doc_id][chunk_index].get("chunk_page_end", ""),
+                self.data[doc_id][chunk_index].get("chunk_page_start", None),
+                self.data[doc_id][chunk_index].get("chunk_page_end", None),
             )
         return None
 

--- a/dsrag/database/chunk/basic_db.py
+++ b/dsrag/database/chunk/basic_db.py
@@ -37,6 +37,14 @@ class BasicChunkDB(ChunkDB):
         if doc_id in self.data and chunk_index in self.data[doc_id]:
             return self.data[doc_id][chunk_index]["chunk_text"]
         return None
+    
+    def get_chunk_page_numbers(self, doc_id: str, chunk_index: int) -> Optional[tuple[int, int]]:
+        if doc_id in self.data and chunk_index in self.data[doc_id]:
+            return (
+                self.data[doc_id][chunk_index].get("chunk_page_start", ""),
+                self.data[doc_id][chunk_index].get("chunk_page_end", ""),
+            )
+        return None
 
     def get_document(
         self, doc_id: str, include_content: bool = False

--- a/dsrag/database/chunk/db.py
+++ b/dsrag/database/chunk/db.py
@@ -49,6 +49,13 @@ class ChunkDB(ABC):
         pass
 
     @abstractmethod
+    def get_chunk_page_numbers(self, doc_id: str, chunk_index: int) -> Optional[tuple[int, int]]:
+        """
+        Retrieve the page numbers of a specific chunk from a given document ID.
+        """
+        pass
+
+    @abstractmethod
     def get_document(self, doc_id: str) -> Optional[FormattedDocument]:
         """
         Retrieve all chunks from a given document ID.
@@ -62,18 +69,21 @@ class ChunkDB(ABC):
         """
         pass
 
+    @abstractmethod
     def get_document_summary(self, doc_id: str, chunk_index: int) -> Optional[str]:
         """
         Retrieve the document summary of a specific chunk from a given document ID.
         """
         pass
 
+    @abstractmethod
     def get_section_title(self, doc_id: str, chunk_index: int) -> Optional[str]:
         """
         Retrieve the section title of a specific chunk from a given document ID.
         """
         pass
 
+    @abstractmethod
     def get_section_summary(self, doc_id: str, chunk_index: int) -> Optional[str]:
         """
         Retrieve the section summary of a specific chunk from a given document ID.

--- a/dsrag/database/chunk/sqlite_db.py
+++ b/dsrag/database/chunk/sqlite_db.py
@@ -25,6 +25,8 @@ class SQLiteDB(ChunkDB):
             {"name": "chunk_text", "type": "TEXT"},
             {"name": "chunk_index", "type": "INT"},
             {"name": "chunk_length", "type": "INT"},
+            {"name": "chunk_page_start", "type": "INT"},
+            {"name": "chunk_page_end", "type": "INT"},
             {"name": "created_on", "type": "TEXT"},
             {"name": "supp_id", "type": "TEXT"},
             {"name": "metadata", "type": "TEXT"},
@@ -72,9 +74,11 @@ class SQLiteDB(ChunkDB):
             section_title = chunk.get("section_title", "")
             section_summary = chunk.get("section_summary", "")
             chunk_text = chunk.get("chunk_text", "")
+            chunk_page_start = chunk.get("chunk_page_start", "")
+            chunk_page_end = chunk.get("chunk_page_end", "")
             chunk_length = len(chunk_text)
             c.execute(
-                "INSERT INTO documents (doc_id, document_title, document_summary, section_title, section_summary, chunk_text, chunk_index, chunk_length, created_on, supp_id, metadata) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                "INSERT INTO documents (doc_id, document_title, document_summary, section_title, section_summary, chunk_text, chunk_page_start, chunk_page_end, chunk_index, chunk_length, created_on, supp_id, metadata) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     doc_id,
                     document_title,
@@ -82,6 +86,8 @@ class SQLiteDB(ChunkDB):
                     section_title,
                     section_summary,
                     chunk_text,
+                    chunk_page_start,
+                    chunk_page_end,
                     chunk_index,
                     chunk_length,
                     created_on,
@@ -118,7 +124,7 @@ class SQLiteDB(ChunkDB):
         results = c.fetchall()
         conn.close()
 
-        # If there are no results, return an empty dictionary
+        # If there are no results, return None
         if not results:
             return None
 
@@ -163,6 +169,19 @@ class SQLiteDB(ChunkDB):
         conn.close()
         if result:
             return result[0]
+        return None
+    
+    def get_chunk_page_numbers(self, doc_id: str, chunk_index: int) -> Optional[tuple[int, int]]:
+        # Retrieve the chunk page numbers from the sqlite table
+        conn = sqlite3.connect(os.path.join(self.db_path, f"{self.kb_id}.db"))
+        c = conn.cursor()
+        c.execute(
+            f"SELECT chunk_page_start, chunk_page_end FROM documents WHERE doc_id='{doc_id}' AND chunk_index={chunk_index}"
+        )
+        result = c.fetchone()
+        conn.close()
+        if result:
+            return result
         return None
 
     def get_document_title(self, doc_id: str, chunk_index: int) -> Optional[str]:

--- a/dsrag/database/chunk/sqlite_db.py
+++ b/dsrag/database/chunk/sqlite_db.py
@@ -74,8 +74,8 @@ class SQLiteDB(ChunkDB):
             section_title = chunk.get("section_title", "")
             section_summary = chunk.get("section_summary", "")
             chunk_text = chunk.get("chunk_text", "")
-            chunk_page_start = chunk.get("chunk_page_start", "")
-            chunk_page_end = chunk.get("chunk_page_end", "")
+            chunk_page_start = chunk.get("chunk_page_start", None)
+            chunk_page_end = chunk.get("chunk_page_end", None)
             chunk_length = len(chunk_text)
             c.execute(
                 "INSERT INTO documents (doc_id, document_title, document_summary, section_title, section_summary, chunk_text, chunk_page_start, chunk_page_end, chunk_index, chunk_length, created_on, supp_id, metadata) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",

--- a/dsrag/document_parsing.py
+++ b/dsrag/document_parsing.py
@@ -33,12 +33,12 @@ def parse_file(file_path: str) -> str:
         text, pdf_pages = extract_text_from_pdf(file_path)
     elif file_path.endswith(".docx"):
         text = extract_text_from_docx(file_path)
-    elif file_path.endswith(".txt"):
+    elif file_path.endswith(".txt") or file_path.endswith(".md"):
         with open(file_path, "r") as file:
             text = file.read()
     else:
         raise ValueError(
-            "Unsupported file format. Only PDF and DOCX files are supported."
+            "Unsupported file format. Only .txt, .md, .pdf and .docx files are supported."
         )
     
     return text, pdf_pages

--- a/dsrag/document_parsing.py
+++ b/dsrag/document_parsing.py
@@ -1,7 +1,8 @@
 import PyPDF2
 import docx2txt
 
-def extract_text_from_pdf(file_path):
+
+def extract_text_from_pdf(file_path: str) -> tuple[str, list]:
     with open(file_path, 'rb') as file:
         # Create a PDF reader object
         pdf_reader = PyPDF2.PdfReader(file)
@@ -10,14 +11,71 @@ def extract_text_from_pdf(file_path):
         extracted_text = ""
 
         # Loop through all the pages in the PDF file
+        pages = []
         for page_num in range(len(pdf_reader.pages)):
             # Extract the text from the current page
             page_text = pdf_reader.pages[page_num].extract_text()
+            pages.append(page_text)
 
             # Add the extracted text to the final text
             extracted_text += page_text
 
-    return extracted_text
+    return extracted_text, pages
 
-def extract_text_from_docx(file_path):
+
+def extract_text_from_docx(file_path: str) -> str:
     return docx2txt.process(file_path)
+
+
+def parse_file(file_path: str) -> str:
+    pdf_pages = None
+    if file_path.endswith(".pdf"):
+        text, pdf_pages = extract_text_from_pdf(file_path)
+    elif file_path.endswith(".docx"):
+        text = extract_text_from_docx(file_path)
+    elif file_path.endswith(".txt"):
+        with open(file_path, "r") as file:
+            text = file.read()
+    else:
+        raise ValueError(
+            "Unsupported file format. Only PDF and DOCX files are supported."
+        )
+    
+    return text, pdf_pages
+
+
+def get_pages_from_chunks(full_text: str, pages: list[dict], chunks: list) -> list:
+
+    current_page_index = 0
+    current_page_start = 0
+
+    formatted_chunks = []
+
+    for chunk in chunks:
+        chunk_text = chunk["chunk_text"]
+        chunk_start = full_text.find(chunk_text)
+        chunk_end = chunk_start + len(chunk_text)
+
+        # Determine the page numbers for the current chunk
+        chunk_pages = []
+        while current_page_index < len(pages):
+            page_text = pages[current_page_index]
+            page_num = current_page_index + 1
+            #page_start = current_page_start
+            page_end = current_page_start + len(page_text)
+
+            if chunk_start < page_end:
+                chunk_pages.append(page_num)
+                if chunk_end <= page_end:
+                    break
+
+            current_page_start = page_end
+            current_page_index += 1
+
+        formatted_chunks.append({
+            "chunk_page_start": chunk_pages[0],
+            "chunk_page_end": chunk_pages[-1],
+            **chunk
+        })
+    
+    return formatted_chunks

--- a/dsrag/knowledge_base.py
+++ b/dsrag/knowledge_base.py
@@ -187,7 +187,7 @@ class KnowledgeBase:
         Inputs:
         - doc_id: unique identifier for the document; a file name or path is a good choice
         - text: the full text of the document
-        - file_path: the path to the file containing the document text (if text is not provided)
+        - file_path: the path to the file to be uploaded. Supported file types are .txt, .md, .pdf, and .docx
         - document_title: the title of the document (if not provided, either the doc_id or an LLM-generated title will be used, depending on the auto_context_config)
         - auto_context_config: a dictionary with configuration parameters for AutoContext
             - use_generated_title: bool - whether to use an LLM-generated title if no title is provided (default is True)
@@ -355,8 +355,8 @@ class KnowledgeBase:
                     "document_summary": chunk["document_summary"],
                     "section_title": chunk["section_title"],
                     "section_summary": chunk["section_summary"],
-                    "chunk_page_start": chunk.get("chunk_page_start", ""),
-                    "chunk_page_end": chunk.get("chunk_page_end", ""),
+                    "chunk_page_start": chunk.get("chunk_page_start", None),
+                    "chunk_page_end": chunk.get("chunk_page_end", None),
                 }
                 for i, chunk in enumerate(chunks)
             },

--- a/tests/integration/test_chunk_and_segment_headers.py
+++ b/tests/integration/test_chunk_and_segment_headers.py
@@ -20,7 +20,7 @@ class TestChunkAndSegmentHeaders(unittest.TestCase):
         file_path = os.path.join(script_dir, "../data/levels_of_agi.pdf")
 
         # extract text from the pdf
-        text = extract_text_from_pdf(file_path)
+        text, _ = extract_text_from_pdf(file_path)
         
         kb_id = "levels_of_agi"
         kb = KnowledgeBase(kb_id=kb_id, exists_ok=False)
@@ -61,7 +61,7 @@ class TestChunkAndSegmentHeaders(unittest.TestCase):
         file_path = os.path.join(script_dir, "../data/levels_of_agi.pdf")
 
         # extract text from the pdf
-        text = extract_text_from_pdf(file_path)
+        text, _ = extract_text_from_pdf(file_path)
         
         kb_id = "levels_of_agi"
         kb = KnowledgeBase(kb_id=kb_id, exists_ok=False)

--- a/tests/integration/test_create_kb_and_query_chromadb.py
+++ b/tests/integration/test_create_kb_and_query_chromadb.py
@@ -6,7 +6,6 @@ import unittest
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
 from dsrag.knowledge_base import KnowledgeBase
-from dsrag.document_parsing import extract_text_from_pdf
 from dsrag.database.vector import ChromaDB
 
 class TestCreateKB(unittest.TestCase):
@@ -20,14 +19,13 @@ class TestCreateKB(unittest.TestCase):
         file_path = os.path.join(script_dir, "../data/levels_of_agi.pdf")
 
         kb_id = "levels_of_agi"
-        document_text = extract_text_from_pdf(file_path)
 
         vector_db = ChromaDB(kb_id=kb_id)
         kb = KnowledgeBase(kb_id=kb_id, vector_db=vector_db, exists_ok=False)
         kb.add_document(
             doc_id="levels_of_agi.pdf",
             document_title="Levels of AGI",
-            text=document_text,
+            file_path=file_path,
             semantic_sectioning_config={"use_semantic_sectioning": False},
             auto_context_config={
                 "use_generated_title": False,
@@ -45,6 +43,9 @@ class TestCreateKB(unittest.TestCase):
         ]
         segment_info = kb.query(search_queries)
         self.assertGreater(len(segment_info[0]), 0)
+        # Assert that the chunk page start and end are correct
+        self.assertEqual(segment_info[0]["chunk_page_start"], 5)
+        self.assertEqual(segment_info[0]["chunk_page_end"], 8)
 
     def test__002_test_query_with_metadata_filter(self):
 
@@ -68,6 +69,8 @@ class TestCreateKB(unittest.TestCase):
         segment_info = kb.query(search_queries, metadata_filter=metadata_filter, rse_params={"minimum_value": 0})
         self.assertEqual(len(segment_info), 1)
         self.assertEqual(segment_info[0]["doc_id"], "test_doc")
+        self.assertEqual(segment_info[0]["chunk_page_start"], "")
+        self.assertEqual(segment_info[0]["chunk_page_end"], "")
         
 
     def test__003_remove_document(self):

--- a/tests/integration/test_create_kb_and_query_chromadb.py
+++ b/tests/integration/test_create_kb_and_query_chromadb.py
@@ -69,8 +69,8 @@ class TestCreateKB(unittest.TestCase):
         segment_info = kb.query(search_queries, metadata_filter=metadata_filter, rse_params={"minimum_value": 0})
         self.assertEqual(len(segment_info), 1)
         self.assertEqual(segment_info[0]["doc_id"], "test_doc")
-        self.assertEqual(segment_info[0]["chunk_page_start"], "")
-        self.assertEqual(segment_info[0]["chunk_page_end"], "")
+        self.assertEqual(segment_info[0]["chunk_page_start"], None)
+        self.assertEqual(segment_info[0]["chunk_page_end"], None)
         
 
     def test__003_remove_document(self):

--- a/tests/unit/test_chunk_db.py
+++ b/tests/unit/test_chunk_db.py
@@ -50,6 +50,36 @@ class TestChunkDB(unittest.TestCase):
         retrieved_chunk = db.get_chunk_text(doc_id, 0)
         self.assertEqual(retrieved_chunk, chunks[0]["chunk_text"])
 
+    def test__get_chunk_page_numbers(self):
+
+        db = BasicChunkDB(self.kb_id, self.storage_directory)
+        doc_id = "doc1"
+
+        chunks = {
+            0: {
+                "chunk_text": "Content of chunk 1",
+                "document_title": "Title of document 1",
+                "document_summary": "Summary of document 1",
+                "section_title": "Section title 1",
+                "section_summary": "Section summary 1",
+                "chunk_page_start": 1,
+                "chunk_page_end": 2,
+            },
+            1: {
+                "chunk_text": "Content of chunk 2",
+                "document_title": "Title of document 2",
+                "document_summary": "Summary of document 2",
+                "section_title": "Section title 2",
+                "section_summary": "Section summary 2",
+            },
+        }
+        db.add_document(doc_id, chunks)
+        page_numbers = db.get_chunk_page_numbers(doc_id, 0)
+        self.assertEqual(page_numbers, (1, 2))
+
+        page_numbers = db.get_chunk_page_numbers(doc_id, 1)
+        self.assertEqual(page_numbers, ("", ""))
+
     def test__get_document_title(self):
         db = BasicChunkDB(self.kb_id, self.storage_directory)
         doc_id = "doc1"
@@ -169,6 +199,36 @@ class TestSQLiteDB(unittest.TestCase):
         db.add_document(doc_id, chunks)
         retrieved_chunk = db.get_chunk_text(doc_id, 0)
         self.assertEqual(retrieved_chunk, chunks[0]["chunk_text"])
+
+    def test__get_chunk_page_numbers(self):
+            
+        db = SQLiteDB(self.kb_id, self.storage_directory)
+        doc_id = "doc1"
+
+        chunks = {
+            0: {
+                "chunk_text": "Content of chunk 1",
+                "document_title": "Title of document 1",
+                "document_summary": "Summary of document 1",
+                "section_title": "Section title 1",
+                "section_summary": "Section summary 1",
+                "chunk_page_start": 1,
+                "chunk_page_end": 2,
+            },
+            1: {
+                "chunk_text": "Content of chunk 2",
+                "document_title": "Title of document 2",
+                "document_summary": "Summary of document 2",
+                "section_title": "Section title 2",
+                "section_summary": "Section summary 2",
+            },
+        }
+        db.add_document(doc_id, chunks)
+        page_numbers = db.get_chunk_page_numbers(doc_id, 0)
+        self.assertEqual(page_numbers, (1, 2))
+
+        page_numbers = db.get_chunk_page_numbers(doc_id, 1)
+        self.assertEqual(page_numbers, ("", ""))
 
     def test__get_document_title(self):
         db = SQLiteDB(self.kb_id, self.storage_directory)

--- a/tests/unit/test_chunk_db.py
+++ b/tests/unit/test_chunk_db.py
@@ -78,7 +78,7 @@ class TestChunkDB(unittest.TestCase):
         self.assertEqual(page_numbers, (1, 2))
 
         page_numbers = db.get_chunk_page_numbers(doc_id, 1)
-        self.assertEqual(page_numbers, ("", ""))
+        self.assertEqual(page_numbers, (None, None))
 
     def test__get_document_title(self):
         db = BasicChunkDB(self.kb_id, self.storage_directory)
@@ -228,7 +228,7 @@ class TestSQLiteDB(unittest.TestCase):
         self.assertEqual(page_numbers, (1, 2))
 
         page_numbers = db.get_chunk_page_numbers(doc_id, 1)
-        self.assertEqual(page_numbers, ("", ""))
+        self.assertEqual(page_numbers, (None, None))
 
     def test__get_document_title(self):
         db = SQLiteDB(self.kb_id, self.storage_directory)

--- a/tests/unit/test_document_parsing.py
+++ b/tests/unit/test_document_parsing.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+from dsrag.document_parsing import get_pages_from_chunks
+
+class TestPDFPages(unittest.TestCase):
+
+    def test_get_pdf_pages(self):
+
+        full_text = "This is some sample text for testing purposes. It doesn't really matter what is in here, just something to test with."
+        pages = [
+            "This is some sample text for testing purposes.",
+            "It doesn't really matter what is in here, just something to test with."
+        ]
+        chunks = [
+            {"chunk_text": "This is some sample text for"},
+            {"chunk_text": "testing purposes. It doesn't really matter"},
+            {"chunk_text": "what is in here, just something to test with."}
+        ]
+
+        formatted_chunks = get_pages_from_chunks(full_text, pages, chunks)
+
+        self.assertEqual(len(formatted_chunks), 3)
+        self.assertEqual(formatted_chunks[0]["chunk_page_start"], 1)
+        self.assertEqual(formatted_chunks[0]["chunk_page_end"], 1)
+        self.assertEqual(formatted_chunks[1]["chunk_page_start"], 1)
+        self.assertEqual(formatted_chunks[1]["chunk_page_end"], 2)
+        self.assertEqual(formatted_chunks[2]["chunk_page_start"], 2)
+        self.assertEqual(formatted_chunks[2]["chunk_page_end"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Support for saving the pdf page number in the chunk and vector metadata, and returning it in the query results. The `add_document` function now optionally takes in a `file_path` instead of just text