### PR TITLE
API key load bug fix

### DIFF
--- a/dsrag/llm.py
+++ b/dsrag/llm.py
@@ -33,14 +33,14 @@ class LLM(ABC):
 
 class OpenAIChatAPI(LLM):
     def __init__(self, model: str = "gpt-4o-mini", temperature: float = 0.2, max_tokens: int = 1000):
-        from openai import OpenAI
-        self.client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
         self.model = model
         self.temperature = temperature
         self.max_tokens = max_tokens
 
     def make_llm_call(self, chat_messages: list[dict]) -> str:
-        response = self.client.chat.completions.create(
+        from openai import OpenAI
+        client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+        response = client.chat.completions.create(
             model=self.model,
             messages=chat_messages,
             max_tokens=self.max_tokens,
@@ -60,13 +60,13 @@ class OpenAIChatAPI(LLM):
 
 class AnthropicChatAPI(LLM):
     def __init__(self, model: str = "claude-3-haiku-20240307", temperature: float = 0.2, max_tokens: int = 1000):
-        from anthropic import Anthropic
-        self.client = Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
         self.model = model
         self.temperature = temperature
         self.max_tokens = max_tokens
 
     def make_llm_call(self, chat_messages: list[dict]) -> str:
+        from anthropic import Anthropic
+        client = Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
         system_message = ""
         num_system_messages = 0
         normal_chat_messages = []
@@ -79,7 +79,7 @@ class AnthropicChatAPI(LLM):
             else:
                 normal_chat_messages.append(message)
 
-        message = self.client.messages.create(
+        message = client.messages.create(
             system=system_message,
             messages=normal_chat_messages,
             model=self.model,

--- a/tests/integration/test_save_and_load.py
+++ b/tests/integration/test_save_and_load.py
@@ -18,7 +18,7 @@ class TestSaveAndLoad(unittest.TestCase):
         self.cleanup()
 
         # initialize a KnowledgeBase object
-        auto_context_model = OpenAIChatAPI(model="gpt-3.5-turbo")
+        auto_context_model = OpenAIChatAPI(model="gpt-4o-mini")
         embedding_model = VoyageAIEmbedding(model="voyage-code-2")
         kb = KnowledgeBase(kb_id="test_kb", auto_context_model=auto_context_model, embedding_model=embedding_model, exists_ok=False)
 
@@ -26,7 +26,7 @@ class TestSaveAndLoad(unittest.TestCase):
         kb1 = KnowledgeBase(kb_id="test_kb")
 
         # verify that the KnowledgeBase object has the right parameters
-        self.assertEqual(kb1.auto_context_model.model, "gpt-3.5-turbo")
+        self.assertEqual(kb1.auto_context_model.model, "gpt-4o-mini")
         self.assertEqual(kb1.embedding_model.model, "voyage-code-2")
 
         # delete the KnowledgeBase object


### PR DESCRIPTION
API key loading for `OpenAIChatAPI` and `AnthropicChatAPI` previously occurred in the `__init__` functions, which is unnecessary and led to the requirement of an `ANTHROPIC_API_KEY` being available to run the example notebook, even though no API calls are ever made. This PR moves the API key loading to the `make_llm_call` function where it's actually needed.

Closes #30 