### PR TITLE
Adding boolen in rse config to disable chunk length adjustment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,7 +157,7 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
 
 # Embedded Weaviate data
 weaviate

--- a/dsrag/knowledge_base.py
+++ b/dsrag/knowledge_base.py
@@ -523,6 +523,9 @@ class KnowledgeBase:
             "top_k_for_document_selection",
             default_rse_params["top_k_for_document_selection"],
         )
+        chunk_length_adjustment = rse_params.get(
+            "chunk_length_adjustment", default_rse_params["chunk_length_adjustment"]
+        )
 
         overall_max_length += (
             len(search_queries) - 1
@@ -555,6 +558,7 @@ class KnowledgeBase:
             unique_document_ids=unique_document_ids,
             irrelevant_chunk_penalty=irrelevant_chunk_penalty,
             decay_rate=decay_rate,
+            chunk_length_adjustment=chunk_length_adjustment,
         )
         best_segments, scores = get_best_segments(
             all_relevance_values=all_relevance_values,

--- a/dsrag/rse.py
+++ b/dsrag/rse.py
@@ -106,7 +106,7 @@ def get_chunk_value(chunk_info: dict, irrelevant_chunk_penalty: float, decay_rat
     v = np.exp(-rank / decay_rate)*absolute_relevance_value - irrelevant_chunk_penalty
     return v
 
-def get_relevance_values(all_ranked_results: list[list], meta_document_length: int, document_start_points: dict[str, int], unique_document_ids: list[str], irrelevant_chunk_penalty: float, decay_rate: int = 20):
+def get_relevance_values(all_ranked_results: list[list], meta_document_length: int, document_start_points: dict[str, int], unique_document_ids: list[str], irrelevant_chunk_penalty: float, decay_rate: int = 20, chunk_length_adjustment = True):
     # get the relevance values for each chunk in the meta-document, separately for each query
     all_relevance_values = []
     for ranked_results in all_ranked_results:
@@ -127,9 +127,10 @@ def get_relevance_values(all_ranked_results: list[list], meta_document_length: i
         # convert the relevance ranks and other info to chunk values
         relevance_values = [get_chunk_value(chunk_info, irrelevant_chunk_penalty, decay_rate) for chunk_info in all_chunk_info]
 
-        # adjust the relevance values for the length of the chunks
-        chunk_lengths = [chunk_info.get('chunk_length', 0.0) for chunk_info in all_chunk_info]
-        relevance_values = adjust_relevance_values_for_chunk_length(relevance_values, chunk_lengths)
+        if chunk_length_adjustment:
+            # adjust the relevance values for the length of the chunks
+            chunk_lengths = [chunk_info.get('chunk_length', 0.0) for chunk_info in all_chunk_info]
+            relevance_values = adjust_relevance_values_for_chunk_length(relevance_values, chunk_lengths)
 
         all_relevance_values.append(relevance_values)
     
@@ -155,6 +156,7 @@ RSE_PARAMS_PRESETS = {
         'overall_max_length_extension': 5,
         'decay_rate': 30,
         'top_k_for_document_selection': 10,
+        'chunk_length_adjustment': True,
     },
     "precision": {
         'max_length': 15,
@@ -164,6 +166,7 @@ RSE_PARAMS_PRESETS = {
         'overall_max_length_extension': 5,
         'decay_rate': 30,
         'top_k_for_document_selection': 10,
+        'chunk_length_adjustment': True,
     },
     "find_all": {
         'max_length': 40,
@@ -173,5 +176,6 @@ RSE_PARAMS_PRESETS = {
         'overall_max_length_extension': 0,
         'decay_rate': 200,
         'top_k_for_document_selection': 200,
+        'chunk_length_adjustment': True,
     },
 }


### PR DESCRIPTION
In use cases where documents range from chunk lengths of 40 - 700 characters it's better to simply disable adjusting the relevance scores via length. This keeps the defaults the same but allows a query to be made without the adjustment.