### PR TITLE
Add support for using existing page images for VLM file parsing

### DIFF
--- a/dsrag/dsparse/file_parsing/file_system.py
+++ b/dsrag/dsparse/file_parsing/file_system.py
@@ -59,7 +59,7 @@ class FileSystem(ABC):
         pass
 
     @abstractmethod
-    def get_all_files(self, kb_id: str, doc_id: str) -> List[str]:
+    def get_all_png_files(self, kb_id: str, doc_id: str) -> List[str]:
         pass
 
 
@@ -137,7 +137,7 @@ class LocalFileSystem(FileSystem):
             image_file_paths.append(image_file_path)
         return image_file_paths
     
-    def get_all_files(self, kb_id: str, doc_id: str) -> List[str]:
+    def get_all_png_files(self, kb_id: str, doc_id: str) -> List[str]:
         """
         Same as get_files except it returns all the files instead of just those in a page range
         """
@@ -303,7 +303,7 @@ class S3FileSystem(FileSystem):
             
         return file_paths
     
-    def get_all_files(self, kb_id: str, doc_id: str) -> List[str]:
+    def get_all_png_files(self, kb_id: str, doc_id: str) -> List[str]:
         """
         Get all PNG files from a specific S3 directory and download them to local storage.
         Returns a sorted list of local file paths.

--- a/dsrag/dsparse/file_parsing/file_system.py
+++ b/dsrag/dsparse/file_parsing/file_system.py
@@ -304,7 +304,60 @@ class S3FileSystem(FileSystem):
         return file_paths
     
     def get_all_files(self, kb_id: str, doc_id: str) -> List[str]:
-        raise NotImplementedError("This function is not implemented for S3 storage.")
+        """
+        Get all PNG files from a specific S3 directory and download them to local storage.
+        Returns a sorted list of local file paths.
+        
+        Args:
+            kb_id (str): Knowledge base ID
+            doc_id (str): Document ID
+            
+        Returns:
+            List[str]: Sorted list of local file paths for the downloaded images
+        """
+        prefix = f"{kb_id}/{doc_id}/"
+        s3_client = self.create_s3_client()
+        
+        try:
+            # List all objects with the specified prefix
+            response = s3_client.list_objects_v2(
+                Bucket=self.bucket_name,
+                Prefix=prefix
+            )
+            
+            if 'Contents' not in response:
+                return []
+            
+            # Filter for PNG files
+            png_files = [obj['Key'] for obj in response['Contents'] 
+                        if obj['Key'].lower().endswith('.png')]
+            
+            # Create local directory if it doesn't exist
+            output_folder = os.path.join(self.base_path, kb_id, doc_id)
+            os.makedirs(output_folder, exist_ok=True)
+            
+            # Download each file
+            local_file_paths = []
+            for s3_key in png_files:
+                local_path = os.path.join(self.base_path, s3_key)
+                try:
+                    s3_client.download_file(
+                        self.bucket_name,
+                        s3_key,
+                        local_path
+                    )
+                    local_file_paths.append(local_path)
+                except Exception as e:
+                    print(f"Error downloading file {s3_key}: {e}")
+                    continue
+            
+            # Sort the files by page number, similar to LocalFileSystem
+            local_file_paths.sort(key=lambda x: int(x.split('_')[-1].split('.')[0]))
+            return local_file_paths
+            
+        except Exception as e:
+            print(f"Error listing/downloading files from S3: {e}")
+            return []
     
 
     def to_dict(self):

--- a/dsrag/dsparse/file_parsing/file_system.py
+++ b/dsrag/dsparse/file_parsing/file_system.py
@@ -58,6 +58,9 @@ class FileSystem(ABC):
     def get_files(self, kb_id: str, doc_id: str, page_start: int, page_end: int) -> List[str]:
         pass
 
+    @abstractmethod
+    def get_all_files(self, kb_id: str, doc_id: str) -> List[str]:
+        pass
 
 
 class LocalFileSystem(FileSystem):
@@ -132,6 +135,22 @@ class LocalFileSystem(FileSystem):
             if not os.path.exists(image_file_path):
                 continue
             image_file_paths.append(image_file_path)
+        return image_file_paths
+    
+    def get_all_files(self, kb_id: str, doc_id: str) -> List[str]:
+        """
+        Same as get_files except it returns all the files instead of just those in a page range
+        """
+        page_images_path = os.path.join(self.base_path, kb_id, doc_id)
+        image_file_paths = []
+        for file in os.listdir(page_images_path):
+            # Make sure the file is an image
+            if not file.endswith('.png'):
+                continue
+            image_file_paths.append(os.path.join(page_images_path, file))
+
+        # Sort the files by page number
+        image_file_paths.sort(key=lambda x: int(x.split('_')[-1].split('.')[0]))
         return image_file_paths
 
 
@@ -283,6 +302,9 @@ class S3FileSystem(FileSystem):
                 print ("Error downloading file:", e)
             
         return file_paths
+    
+    def get_all_files(self, kb_id: str, doc_id: str) -> List[str]:
+        raise NotImplementedError("This function is not implemented for S3 storage.")
     
 
     def to_dict(self):

--- a/dsrag/dsparse/file_parsing/vlm_file_parsing.py
+++ b/dsrag/dsparse/file_parsing/vlm_file_parsing.py
@@ -173,14 +173,26 @@ def parse_file(pdf_path: str, kb_id: str, doc_id: str, vlm_config: VLMConfig, fi
     Given a PDF file, extract the content of each page using a VLM model.
     
     Inputs
-    - pdf_path: str, path to the PDF file
-    - save_path: str, path to the base directory where everything is saved (i.e. {user_id}/{job_id})
+    - pdf_path: str, path to the PDF file - can be an empty string if images_already_exist is True
+    - kb_id: str, knowledge base ID
+    - doc_id: str, document ID
     - vlm_config: dict, configuration for the VLM model. For Vertex this should include project_id and location.
+    - file_system: FileSystem, object for interacting with the file system where the images are stored
+    - images_already_exist: bool, whether the images have already been extracted and saved
     
     Outputs
     - all_page_content: list of Elements
+
+    Saves
+    - images of each page of the PDF (if images_already_exist is False)
+    - JSON files of the content of each page
     """
-    image_file_paths = pdf_to_images(pdf_path, kb_id, doc_id, file_system)
+    images_already_exist = vlm_config.get("images_already_exist", False)
+    if images_already_exist:
+        image_file_paths = file_system.get_all_files(kb_id, doc_id)
+    else:
+        image_file_paths = pdf_to_images(pdf_path, kb_id, doc_id, file_system)
+    
     all_page_content_dict = {}
 
     element_types = vlm_config.get("element_types", default_element_types)

--- a/dsrag/dsparse/file_parsing/vlm_file_parsing.py
+++ b/dsrag/dsparse/file_parsing/vlm_file_parsing.py
@@ -178,7 +178,6 @@ def parse_file(pdf_path: str, kb_id: str, doc_id: str, vlm_config: VLMConfig, fi
     - doc_id: str, document ID
     - vlm_config: dict, configuration for the VLM model. For Vertex this should include project_id and location.
     - file_system: FileSystem, object for interacting with the file system where the images are stored
-    - images_already_exist: bool, whether the images have already been extracted and saved
     
     Outputs
     - all_page_content: list of Elements

--- a/dsrag/dsparse/file_parsing/vlm_file_parsing.py
+++ b/dsrag/dsparse/file_parsing/vlm_file_parsing.py
@@ -188,7 +188,7 @@ def parse_file(pdf_path: str, kb_id: str, doc_id: str, vlm_config: VLMConfig, fi
     """
     images_already_exist = vlm_config.get("images_already_exist", False)
     if images_already_exist:
-        image_file_paths = file_system.get_all_files(kb_id, doc_id)
+        image_file_paths = file_system.get_all_png_files(kb_id, doc_id)
     else:
         image_file_paths = pdf_to_images(pdf_path, kb_id, doc_id, file_system)
     

--- a/dsrag/dsparse/main.py
+++ b/dsrag/dsparse/main.py
@@ -37,6 +37,7 @@ def parse_and_chunk(
             - exclude_elements: a list of element types to exclude from the parsed text. Default is ["Header", "Footer"].
             - element_types: a list of dictionaries, each containing 'name', 'instructions', and 'is_visual' keys
                 - default (defined in element_types.py) will be used if not provided
+            - images_already_exist: bool, whether the images have already been extracted and saved (default is False)
         - always_save_page_images: bool - whether to save page images even if VLM is not used (default is False)
     - semantic_sectioning_config: a dictionary with configuration for the semantic sectioning model (defaults will be used if not provided)
         - use_semantic_sectioning: if False, semantic sectioning will be skipped (default is True)

--- a/dsrag/knowledge_base.py
+++ b/dsrag/knowledge_base.py
@@ -225,6 +225,7 @@ class KnowledgeBase:
                 - location: the GCP location (required if provider is "vertex_ai")
                 - save_path: the path to save intermediate files created during VLM processing
                 - exclude_elements: a list of element types to exclude from the parsed text. Default is ["Header", "Footer"].
+                - images_already_exist: bool, whether the images have already been extracted and saved (default is False)
             - always_save_page_images: bool - whether to save page images even if VLM is not used (default is False)
         - semantic_sectioning_config: a dictionary with configuration for the semantic sectioning model (defaults will be used if not provided)
             - llm_provider: the LLM provider to use for semantic sectioning - only "openai" and "anthropic" are supported at the moment


### PR DESCRIPTION
Useful if you want to create the page images first (still using the FileSystem class) so you can do other sorts of VLM processing with them, such as document type classification, before using them for RAG.