### PR TITLE
expose chunk_count in FormattedDocument

### DIFF
--- a/dsrag/database/chunk/basic_db.py
+++ b/dsrag/database/chunk/basic_db.py
@@ -71,6 +71,7 @@ class BasicChunkDB(ChunkDB):
                 content=full_document_string if include_content else None,
                 summary=cast(str, document[0].get("document_summary", "")),
                 created_on=None,
+                chunk_count=len(document.items())
             )
 
         else:

--- a/dsrag/database/chunk/dynamo_db.py
+++ b/dsrag/database/chunk/dynamo_db.py
@@ -315,7 +315,8 @@ class DynamoDB(ChunkDB):
                 content=full_document_string if include_content else None,
                 summary=summary,
                 created_on=created_on,
-                metadata=metadata
+                metadata=metadata,
+                chunk_count=len(items)
             )
 
         except Exception as e:

--- a/dsrag/database/chunk/sqlite_db.py
+++ b/dsrag/database/chunk/sqlite_db.py
@@ -157,7 +157,8 @@ class SQLiteDB(ChunkDB):
             content=full_document_string if include_content else None,
             summary=summary,
             created_on=created_on,
-            metadata=metadata
+            metadata=metadata,
+            chunk_count=len(results)
         )
 
     def get_chunk_text(self, doc_id: str, chunk_index: int) -> Optional[str]:

--- a/dsrag/database/chunk/types.py
+++ b/dsrag/database/chunk/types.py
@@ -2,7 +2,6 @@ from datetime import datetime
 from typing import Optional
 from typing_extensions import TypedDict
 
-
 class FormattedDocument(TypedDict):
     id: str
     title: str
@@ -11,3 +10,4 @@ class FormattedDocument(TypedDict):
     created_on: Optional[datetime]
     supp_id: Optional[str]
     metadata: Optional[dict]
+    chunk_count: int


### PR DESCRIPTION
My use-case is that I want to repurpose the chunk titles and summaries that dsRag creates for other purposes outside of the dsRAG system (e.g., compare the embeddings that dsRag creates using this generated text to embeddings that use the same data but which aren't integrated with dsRAG, potentially to display this information to the user, ...).

For the current api of ChunkDB I couldn't find a way to actually spin through this data. I have to already have a chunk_id in hand to use the existing APIs. With chunk_count, I can iterate through each chunk in each doc with a loop like this:

```python
doc = chunk_db.get_document(doc_id, include_content=False)

for i in range(0, doc["chunk_count"]):
    title = chunk_db.get_section_title(doc_id, i)
    description = chunk_db.get_section_summary(doc_id, i)
 ```

 And do everything else I need to do using only what's in the API already.
 
I may be on a wrong track here. If so, please let me know. For example, after I got this working, I surprised to find that multiple chunks have the same titles and summaries, so I may be misunderstanding the data.
 
 If you need more done in the patch (e.g. unit tests) I'm happy to take change requests. I just wanted you to see the idea before I really invest into it.