### PR TITLE
Prevent unsupported binding parameter (dict) on SQLite3 chatdb

### DIFF
--- a/dsrag/database/chat_thread/sqlite_db.py
+++ b/dsrag/database/chat_thread/sqlite_db.py
@@ -40,8 +40,8 @@ class SQLiteChatThreadDB(ChatThreadDB):
         # Convert the kb_ids list to a string
         chat_thread_params["kb_ids"] = ",".join(chat_thread_params["kb_ids"])
         # Convert rse_params dict to JSON string if it exists
-        if "rse_params" in chat_thread_params and chat_thread_params["rse_params"]:
-            chat_thread_params["rse_params"] = json.dumps(chat_thread_params["rse_params"])
+        if "rse_params" in chat_thread_params:
+            chat_thread_params["rse_params"] = json.dumps(chat_thread_params.get("rse_params") or {})
         # Create the chat thread, using the self.chat_thread_columns list to specify the order of the columns
         query_statement = f"INSERT INTO chat_threads ({', '.join(self.chat_thread_columns)}) VALUES ({'?, '.join(['']*len(self.chat_thread_columns))}?)"
         chat_thread_params_tuple = tuple([chat_thread_params.get(column, "") for column in self.chat_thread_columns])


### PR DESCRIPTION
The code in it's current form will throw an exception if the `rse_params` key exists in `chat_thread_params`, but it an empty dictionary or `None`. An explicit parameter bind will occur because of the following line:

`self.chat_thread_columns = ["thread_id", "supp_id", "kb_ids", "model", "temperature", "system_message", "auto_query_model", "auto_query_guidance", "target_output_length", "max_chat_history_tokens", "rse_params"]
`

Skipping the serialization to string on `None` or empty dict values {} (due to the truthy check) will lead to the following exception:

`sqlite3.ProgrammingError: Error binding parameter: type 'dict' is not supported`

in the following block of code:

```
query_statement = f"INSERT INTO chat_threads ({', '.join(self.chat_thread_columns)}) VALUES ({'?, '.join(['']*len(self.chat_thread_columns))}?)"
chat_thread_params_tuple = tuple([chat_thread_params.get(column, "") for column in self.chat_thread_columns])
c.execute(query_statement, chat_thread_params_tuple)
```

The changes in this PR addresses this issue.
