### PR TITLE
Bugfix: Unpacking retrieval from interactions table 

### DIFF
--- a/dsrag/database/chat_thread/sqlite_db.py
+++ b/dsrag/database/chat_thread/sqlite_db.py
@@ -9,9 +9,9 @@ class SQLiteChatThreadDB(ChatThreadDB):
     def __init__(self, storage_directory: str = "~/dsRAG"):
         # Check if the directory exists, if not create it
         self.chat_thread_columns = ["thread_id", "supp_id", "kb_ids", "model", "temperature", "system_message", "auto_query_model", "auto_query_guidance", "target_output_length", "max_chat_history_tokens", "rse_params"]
-        self.interactions_columns = ["thread_id", "message_id", "user_input", "user_input_timestamp", "model_response", "model_response_timestamp", "relevant_segments", "search_queries", "citations"]
+        self.interactions_columns = ["thread_id", "message_id", "user_input", "user_input_timestamp", "model_response", "model_response_timestamp", "relevant_segments", "search_queries", "citations", "model_response_status"]
         self.chat_thread_column_types = ["VARCHAR(256) PRIMARY KEY", "TEXT", "TEXT", "TEXT", "REAL", "TEXT", "TEXT", "TEXT", "TEXT", "INTEGER", "TEXT"]
-        self.interactions_column_types = ["VARCHAR(256)", "TEXT", "TEXT", "TEXT", "TEXT", "TEXT", "TEXT", "TEXT", "TEXT"]
+        self.interactions_column_types = ["VARCHAR(256)", "TEXT", "TEXT", "TEXT", "TEXT", "TEXT", "TEXT", "TEXT", "TEXT", "TEXT"]
         self.storage_directory = os.path.expanduser(storage_directory)
         if not os.path.exists(self.storage_directory):
             os.makedirs(self.storage_directory)
@@ -125,17 +125,17 @@ class SQLiteChatThreadDB(ChatThreadDB):
         for interaction in interactions:
             formatted_interaction = {
                 "user_input": {
-                    "content": interaction[1],
-                    "timestamp": interaction[2]
+                    "content": interaction[2],
+                    "timestamp": interaction[3]
                 },
                 "model_response": {
-                    "content": interaction[3],
-                    "timestamp": interaction[4],
-                    "citations": json.loads(interaction[7]) if interaction[7] else [],
-                    "status": interaction[8] if len(interaction) > 8 and interaction[8] else "finished"
+                    "content": interaction[4],
+                    "timestamp": interaction[5],
+                    "citations": json.loads(interaction[8]) if interaction[8] else [],
+                    "status": interaction[9] if interaction[9] else "finished"
                 },
-                "relevant_segments": json.loads(interaction[5]),
-                "search_queries": json.loads(interaction[6])
+                "relevant_segments": json.loads(interaction[6]),
+                "search_queries": json.loads(interaction[7])
             }
             formatted_interactions.append(formatted_interaction)
         

--- a/dsrag/dsparse/models/types.py
+++ b/dsrag/dsparse/models/types.py
@@ -37,6 +37,7 @@ class VLMConfig(TypedDict):
     model: Optional[str]
     project_id: Optional[str]
     location: Optional[str]
+    save_path: Optional[str]
     exclude_elements: Optional[list[str]]
     element_types: Optional[list[ElementType]]
     max_workers: Optional[int] = None


### PR DESCRIPTION
The content of the retrieved results (based on` self.interaction_columns`) in `sqlite_db:get_chat_thread_db` does not match the indices at which they are being unpacked. The changes in this PR addresses that issue. Additionally, syncs VLMConfig model fields with documentation and usage. 