### PR TITLE
Robustify search and delete on qdrant_db

### DIFF
--- a/dsrag/database/vector/qdrant_db.py
+++ b/dsrag/database/vector/qdrant_db.py
@@ -145,6 +145,9 @@ class QdrantVectorDB(VectorDB):
         Args:
             doc_id: The UUID of the document to remove.
         """
+        if not self.client.collection_exists(self.kb_id):
+            return
+
         self.client.delete(
             self.kb_id,
             qdrant_client.models.Filter(
@@ -173,6 +176,9 @@ class QdrantVectorDB(VectorDB):
             A list of dictionaries containing the metadata and similarity scores of
             the top-k results.
         """
+        if not self.client.collection_exists(self.kb_id):
+            return []
+
         if isinstance(query_vector, np.ndarray):
             query_vector = query_vector.tolist()
 


### PR DESCRIPTION
Unlike other vector db implementations where the client creates the collection in the constructor, this one creates it on first add (it checks to see if the collection/kb exists first). This means that calling delete or search will throw an exception if the knowledge base doesn't exist. 

I do feel a graceful failure is better from a user experience but it could mask bugs, depending on how the library is integrated with other systems. Other option is to make it consistent with our other vector db implementations deal with this issue, and initialise the kb if it doesn't exist in the constructor - but there is further complications there. In the local .db version, you can only have 1 client per process (which covers all knowledge bases), so if you tie the first (and only instantiation) of the client - then multiple knowledge bases cannot be supported.