### PR TITLE
Semantic sectioning safeguards

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,8 +259,8 @@ file_parsing_config
     - exclude_elements: a list of element types to exclude from the parsed text. Default is ["Header", "Footer"].
 
 semantic_sectioning_config
-- llm_provider: the LLM provider to use for semantic sectioning - only "openai" and "anthropic" are supported at the moment
-- model: the LLM model to use for semantic sectioning
+- llm_provider: the LLM provider to use for semantic sectioning - "openai", "anthropic", and "gemini" are supported
+- model: the LLM model to use for semantic sectioning (e.g., "gpt-4.1-mini", "claude-3-5-haiku-latest", "gemini-2.0-flash")
 - use_semantic_sectioning: if False, semantic sectioning will be skipped (default is True)
 
 chunking_config

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -81,6 +81,29 @@ kb.add_document(
 )
 ```
 
+## Semantic Sectioning Configuration
+
+dsRAG supports semantic sectioning with multiple LLM providers:
+- OpenAI (e.g., `gpt-4.1-mini`)
+- Anthropic (e.g., `claude-3-5-haiku-latest`)
+- Gemini (e.g., `gemini-2.0-flash`)
+
+You can configure semantic sectioning like this:
+
+```python
+semantic_sectioning_config = {
+    "llm_provider": "anthropic",  # or "openai" or "gemini"
+    "model": "claude-3-5-haiku-latest",
+    "use_semantic_sectioning": True
+}
+
+kb.add_document(
+    doc_id="user_manual",
+    file_path="path/to/your/document.pdf",
+    semantic_sectioning_config=semantic_sectioning_config
+)
+```
+
 ## Local-only configuration
 
 If you don't want to use any third-party services, you can configure dsRAG to run fully locally using Ollama. There will be a couple limitations:

--- a/dsrag/knowledge_base.py
+++ b/dsrag/knowledge_base.py
@@ -308,6 +308,10 @@ class KnowledgeBase:
 
                     # Maximum concurrent requests for section summarization
                     "llm_max_concurrent_requests": 5,
+                    
+                    # Minimum average characters per section in a window (default: 500)
+                    # If sections average fewer chars than this, they'll be consolidated
+                    "min_avg_chars_per_section": 500,
 
                     # Custom term mappings (key: term to map to, value: list of terms to map from)
                     "custom_term_mapping": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ voyageai = ["voyageai>=0.1.0"]
 ollama = ["ollama>=0.1.0"]
 anthropic = ["anthropic>=0.37.1"]
 google-generativeai = ["google-generativeai>=0.8.3"]
+google-genai = ["google-genai>=0.1.0"]
 
 # Convenience groups
 all-dbs = [
@@ -76,7 +77,7 @@ all-dbs = [
 ]
 
 all-models = [
-    "dsrag[openai,cohere,voyageai,ollama,anthropic,google-generativeai]"
+    "dsrag[openai,cohere,voyageai,ollama,anthropic,google-generativeai,google-genai]"
 ]
 
 # Complete installation with all optional dependencies


### PR DESCRIPTION
Adds a character-based safeguard to the semantic sectioning process. This prevents the LLM from creating an excessive number of small sections by checking the average characters per section within each processing window and falling back to a single section for that window if the average is too low.

Also, unrelated:
- adds google-genai as optional dependency
- updates docs to reflect that anthropic is support for semantic sectioning